### PR TITLE
Update upstream link from andyboeh to pfriedrich84

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ external_components:
 **Upstream credits:**
 - Encryption/decryption: [QuadCorei8085/elero_protocol](https://github.com/QuadCorei8085/elero_protocol) (MIT)
 - Remote handling: [stanleypa/eleropy](https://github.com/stanleypa/eleropy) (GPLv3)
-- Based on the no-longer-maintained [andyboeh/esphome-elero](https://github.com/andyboeh/esphome-elero)
+- Based on the no-longer-maintained [andyboeh/esphome-elero](https://github.com/pfriedrich84/esphome-elero)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -604,4 +604,4 @@ Dieses Projekt basiert auf der Arbeit von:
 
 - [QuadCorei8085/elero_protocol](https://github.com/QuadCorei8085/elero_protocol) (MIT) - Verschlüsselungs-/Entschlüsselungsstrukturen
 - [stanleypa/eleropy](https://github.com/stanleypa/eleropy) (GPLv3) - Fernbedienungs-Handling
-- [andyboeh/esphome-elero](https://github.com/andyboeh/esphome-elero) - Grundlage für diese Steuerung,eigenes Repository da nicht mehr gepflegt
+- [andyboeh/esphome-elero](https://github.com/pfriedrich84/esphome-elero) - Grundlage für diese Steuerung,eigenes Repository da nicht mehr gepflegt


### PR DESCRIPTION
Replace all references to github.com/andyboeh/esphome-elero with
github.com/pfriedrich84/esphome-elero in README.md and CLAUDE.md.

https://claude.ai/code/session_01RiLXngUBfCvjwV2YrzAWpa