### PR TITLE
Add CC1101 runtime frequency change, fix log names, auto-create sensors from covers

### DIFF
--- a/components/elero/cover/EleroCover.cpp
+++ b/components/elero/cover/EleroCover.cpp
@@ -14,7 +14,7 @@ void EleroCover::dump_config() {
   ESP_LOGCONFIG(TAG, "  Remote Address: 0x%06x", this->command_.remote_addr);
   ESP_LOGCONFIG(TAG, "  Channel: %d", this->command_.channel);
   ESP_LOGCONFIG(TAG, "  Hop: 0x%02x", this->command_.hop);
-  ESP_LOGCONFIG(TAG, "  Pck Inf: 0x%02x 0x%02x", this->command_.pck_inf[0], this->command_.pck_inf[1]);
+  ESP_LOGCONFIG(TAG, "  pck_inf1: 0x%02x, pck_inf2: 0x%02x", this->command_.pck_inf[0], this->command_.pck_inf[1]);
   if (this->open_duration_ > 0)
     ESP_LOGCONFIG(TAG, "  Open Duration: %dms", this->open_duration_);
   if (this->close_duration_ > 0)

--- a/components/elero/elero.cpp
+++ b/components/elero/elero.cpp
@@ -90,7 +90,7 @@ void IRAM_ATTR Elero::set_received() {
 void Elero::dump_config() {
   ESP_LOGCONFIG(TAG, "Elero CC1101:");
   LOG_PIN("  GDO0 Pin: ", this->gdo0_pin_);
-  ESP_LOGCONFIG(TAG, "  FREQ: 0x%02x 0x%02x 0x%02x", this->freq2_, this->freq1_, this->freq0_);
+  ESP_LOGCONFIG(TAG, "  freq2: 0x%02x, freq1: 0x%02x, freq0: 0x%02x", this->freq2_, this->freq1_, this->freq0_);
   ESP_LOGCONFIG(TAG, "  Registered covers: %d", this->address_to_cover_mapping_.size());
 }
 
@@ -101,6 +101,16 @@ void Elero::setup() {
   this->gdo0_pin_->attach_interrupt(Elero::interrupt, this, gpio::INTERRUPT_FALLING_EDGE);
   this->reset();
   this->init();
+}
+
+void Elero::reinit_frequency(uint8_t freq2, uint8_t freq1, uint8_t freq0) {
+  this->received_ = false;
+  this->freq2_ = freq2;
+  this->freq1_ = freq1;
+  this->freq0_ = freq0;
+  this->reset();
+  this->init();
+  ESP_LOGI(TAG, "CC1101 re-initialised: freq2=0x%02x freq1=0x%02x freq0=0x%02x", freq2, freq1, freq0);
 }
 
 void Elero::flush_and_rx() {

--- a/components/elero/elero.h
+++ b/components/elero/elero.h
@@ -173,6 +173,10 @@ class Elero : public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARIT
   void set_freq0(uint8_t freq) { freq0_ = freq; }
   void set_freq1(uint8_t freq) { freq1_ = freq; }
   void set_freq2(uint8_t freq) { freq2_ = freq; }
+  void reinit_frequency(uint8_t freq2, uint8_t freq1, uint8_t freq0);
+  uint8_t get_freq0() const { return freq0_; }
+  uint8_t get_freq1() const { return freq1_; }
+  uint8_t get_freq2() const { return freq2_; }
 
  private:
   uint8_t count_bits(uint8_t byte);

--- a/components/elero_web/elero_web_server.h
+++ b/components/elero_web/elero_web_server.h
@@ -30,6 +30,8 @@ class EleroWebServer : public Component, public AsyncWebHandler {
   void handle_packet_dump_stop(AsyncWebServerRequest *request);
   void handle_get_packets(AsyncWebServerRequest *request);
   void handle_clear_packets(AsyncWebServerRequest *request);
+  void handle_get_frequency(AsyncWebServerRequest *request);
+  void handle_set_frequency(AsyncWebServerRequest *request);
 
   void add_cors_headers(AsyncWebServerResponse *response);
   void send_json_error(AsyncWebServerRequest *request, int code, const char *message);


### PR DESCRIPTION
- CC1101 runtime re-init: add reinit_frequency() to Elero class; expose
  GET /elero/api/frequency and POST /elero/api/frequency/set REST endpoints;
  add a Frequenz card to the web UI with preset dropdown (868.35/868.95/433.92 MHz)
  and manual freq2/freq1/freq0 hex inputs so the frequency can be changed
  without redeploying firmware.

- Log field name consistency: dump_config() now logs "freq2: 0x%02x, freq1:
  0x%02x, freq0: 0x%02x" matching YAML config keys, and "pck_inf1: 0x%02x,
  pck_inf2: 0x%02x" instead of the abbreviated "Pck Inf".

- Auto-create sensors from covers: cover/__init__.py now automatically creates
  an RSSI sensor ("<name> RSSI") and a status text sensor ("<name> Status")
  for every cover when auto_sensors: true (default). Users can override names
  with inline rssi_sensor:/status_sensor: sub-schemas, or opt out entirely
  with auto_sensors: false. Standalone sensor:/text_sensor: platform blocks
  remain fully backward-compatible.

https://claude.ai/code/session_01Cu8rXu66QRvpeYoKbjGhbj