### PR TITLE
fix: discovery now extracts params from 6a command packets, not CA responses

### DIFF
--- a/components/elero/elero.h
+++ b/components/elero/elero.h
@@ -96,6 +96,10 @@ struct DiscoveredBlind {
   uint32_t last_seen;
   uint8_t last_state;
   uint16_t times_seen;
+  // true when params were derived from a command packet (6a/69) — these are
+  // the correct values to use when sending commands to the blind.
+  // false when params came only from a CA/C9 status response (less reliable).
+  bool params_from_command{false};
 };
 
 struct RuntimeBlind {
@@ -253,7 +257,7 @@ class Elero : public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARIT
   void track_discovered_blind(uint32_t src, uint32_t remote, uint8_t channel,
                               uint8_t pck_inf0, uint8_t pck_inf1, uint8_t hop,
                               uint8_t payload_1, uint8_t payload_2,
-                              float rssi, uint8_t state);
+                              float rssi, uint8_t state, bool from_command);
   void capture_raw_packet_(uint8_t fifo_len);
   void mark_last_raw_packet_(bool valid, const char *reason);
 

--- a/components/elero_web/elero_web_server.cpp
+++ b/components/elero_web/elero_web_server.cpp
@@ -239,6 +239,7 @@ void EleroWebServer::handle_get_discovered(AsyncWebServerRequest *request) {
       "\"pck_inf1\":\"0x%02x\","
       "\"pck_inf2\":\"0x%02x\","
       "\"last_seen_ms\":%lu,"
+      "\"params_from_command\":%s,"
       "\"already_configured\":%s,"
       "\"already_adopted\":%s}",
       blind.blind_address,
@@ -253,6 +254,7 @@ void EleroWebServer::handle_get_discovered(AsyncWebServerRequest *request) {
       blind.pck_inf[0],
       blind.pck_inf[1],
       (unsigned long)blind.last_seen,
+      blind.params_from_command ? "true" : "false",
       this->parent_->is_cover_configured(blind.blind_address) ? "true" : "false",
       this->parent_->is_blind_adopted(blind.blind_address) ? "true" : "false"
     );
@@ -560,8 +562,9 @@ void EleroWebServer::handle_get_yaml(AsyncWebServerRequest *request) {
     if (this->parent_->is_cover_configured(blind.blind_address))
       continue;
 
-    char buf[512];
+    char buf[640];
     snprintf(buf, sizeof(buf),
+      "%s"
       "  - platform: elero\n"
       "    blind_address: 0x%06x\n"
       "    channel: %d\n"
@@ -575,6 +578,10 @@ void EleroWebServer::handle_get_yaml(AsyncWebServerRequest *request) {
       "    pck_inf1: 0x%02x\n"
       "    pck_inf2: 0x%02x\n"
       "\n",
+      blind.params_from_command
+        ? ""
+        : "  # WARNING: params derived from status packet only — press a remote\n"
+          "  # button during scan so command packets can be captured for reliable values.\n",
       blind.blind_address, blind.channel, blind.remote_address, ++idx,
       blind.hop, blind.payload_1, blind.payload_2, blind.pck_inf[0], blind.pck_inf[1]
     );


### PR DESCRIPTION
The previous discovery logic passed src (the RF source address) to
track_discovered_blind for every received packet, leading to two bugs:

1. Remote controls appeared as discovered blinds: 6a command packets
   have src = remote address, so the remote itself was tracked as a
   "Discovered Blind" (e.g. 0x458130 in the user's dump).

2. Wrong command params for real blinds: when a CA status packet from a
   blind was processed, byte[6] is NOT the RF channel but a counter-like
   sequence value (~0x23–0x26), and pck_inf/hop/payload bytes reflect
   the blind's response packet format, not the command format.  Using
   these values produced incorrect ESPHome YAML that the blind ignores.

Fix: split discovery handling by packet type:
- 6a/69 (commands from remote): iterate each destination address in the
  packet and store it as a discovered blind with the command's channel,
  pck_inf, hop and payload — these are exactly the values to replicate
  when sending.  src becomes the remote_address of those blinds.
- CA/C9 (status from blind): src is the real blind address; store it as
  a fallback discovery (params_from_command=false).  If a 6a packet is
  seen later for the same address, params are upgraded automatically.

Add DiscoveredBlind::params_from_command flag and expose it in the
JSON API.  The YAML exporter prints a warning comment for entries that
were discovered from status packets only (degraded reliability).

Corrected YAML for the user's setup (derived from 6a command packets):
  blind_address: 0xa9be2f  channel: 6  remote_address: 0x458130
  pck_inf1: 0x6a  pck_inf2: 0x10  hop: 0x00
  payload_1: 0x00  payload_2: 0x03

https://claude.ai/code/session_01NwueGBkKdueYD2hYaAKavZ