### PR TITLE
feat: serve only /elero UI; redirect / to /elero

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -261,11 +261,17 @@ button:
 ### Web UI
 
 ```yaml
-web_server:          # Must be present
+# Use web_server_base (not web_server) to keep only the /elero UI
+# web_server_base is auto-loaded by elero_web, but you can declare it
+# explicitly to configure the port:
+web_server_base:
+  port: 80
 
 elero_web:
   id: elero_web_ui   # Optional ID
 ```
+
+Navigating to `http://<device-ip>/` will redirect to `/elero` automatically.
 
 ---
 
@@ -335,7 +341,7 @@ There are no automated tests in this repository. Validation is done manually on 
 
 - **Wrong frequency**: Most European Elero motors use 868.35 MHz (`freq0=0x7a`). Some use 868.95 MHz (`freq0=0xc0`). If discovery finds nothing, try the alternate frequency.
 - **SPI conflicts**: The CC1101 CS pin must not be shared with any other SPI device.
-- **Missing `web_server:`**: The `elero_web:` component requires a `web_server:` block to be present; it reuses `web_server_base`.
+- **Using `web_server:` instead of `web_server_base:`**: Adding `web_server:` to your YAML re-enables the default ESPHome entity UI at `/`. Use `web_server_base:` (or rely on its auto-load via `elero_web`) to serve only the Elero UI at `/elero`. Navigating to `/` will redirect automatically to `/elero`.
 - **Position tracking**: Leave `open_duration` and `close_duration` at `0s` if you only need open/close without position — setting incorrect durations causes wrong position estimates.
 - **Poll interval `never`**: Set `poll_interval: never` for blinds that reliably push state updates (avoids unnecessary RF traffic). Internally this maps to `uint32_t` max (4 294 967 295 ms).
 

--- a/README.md
+++ b/README.md
@@ -490,8 +490,10 @@ Pro entdecktem Gerät werden protokolliert: Adresse, Remote-Adresse, Kanal, RSSI
 Fuer eine komfortablere Geräteerkennung steht eine optionale Web-Oberflaeche bereit:
 
 ```yaml
-# Web-Server aktivieren (Voraussetzung)
-web_server:
+# HTTP-Server (wird von elero_web automatisch geladen)
+# Nicht web_server: verwenden – das aktiviert die Standard-UI unter / wieder
+web_server_base:
+  port: 80
 
 # Elero Web-UI aktivieren
 elero_web:

--- a/components/elero_web/elero_web_server.cpp
+++ b/components/elero_web/elero_web_server.cpp
@@ -100,7 +100,7 @@ void EleroWebServer::dump_config() {
 bool EleroWebServer::canHandle(AsyncWebServerRequest *request) const {
   if (!this->enabled_) return false;
   const std::string &url = request->url();
-  return url.size() >= 6 && url.substr(0, 6) == "/elero";
+  return url == "/" || (url.size() >= 6 && url.substr(0, 6) == "/elero");
 }
 
 void EleroWebServer::handleRequest(AsyncWebServerRequest *request) {
@@ -108,6 +108,9 @@ void EleroWebServer::handleRequest(AsyncWebServerRequest *request) {
   const auto method = request->method();
 
   if (method == HTTP_OPTIONS) { handle_options(request); return; }
+
+  // ── Redirect root to /elero ──
+  if (url == "/" && method == HTTP_GET) { request->redirect("/elero"); return; }
 
   // ── Static index ──
   if (url == "/elero" && method == HTTP_GET) { handle_index(request); return; }

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -208,13 +208,16 @@ button:
 Optionale Web-Oberfläche zur Geräteerkennung und YAML-Generierung. Erreichbar unter `http://<device-ip>/elero`.
 
 ```yaml
-web_server:
+# web_server_base wird von elero_web automatisch geladen.
+# Explizit angeben um den Port zu konfigurieren:
+web_server_base:
+  port: 80
 
 elero_web:
 ```
 
 **Voraussetzungen:**
-- Die ESPHome `web_server` Komponente (oder eine andere Komponente die `web_server_base` bereitstellt) muss konfiguriert sein.
+- `web_server_base` wird automatisch von `elero_web` geladen. **Nicht** `web_server:` verwenden – das aktiviert die Standard-ESPHome-UI unter `/` wieder. Zugriff auf `/` leitet automatisch zu `/elero` weiter.
 
 **Funktionen:**
 - **RF-Scan steuern** – Scan starten/stoppen direkt im Browser

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -217,7 +217,8 @@ Wenn die Kommunikation funktioniert, kannst du die Adressen deiner Rollladen erm
 Fuege folgendes zu deiner Konfiguration hinzu:
 
 ```yaml
-web_server:
+web_server_base:
+  port: 80
 
 elero_web:
 ```

--- a/example.yaml
+++ b/example.yaml
@@ -43,9 +43,10 @@ button:
     name: "Elero Stop Scan"
     scan_start: false
 
-# Web UI for blind discovery and management
-# Access at http://<device-ip>/elero
-web_server:
+# HTTP server (auto-loaded by elero_web; no default ESPHome UI, only /elero is served)
+# Do NOT use web_server: here — it would re-enable the unwanted default UI at /
+web_server_base:
+  port: 80
 
 elero_web:
   id: elero_web_ui


### PR DESCRIPTION
Remove the default ESPHome web server UI at / by switching from web_server: to web_server_base: in the YAML config. EleroWebServer now also claims the root path in canHandle() and issues a 302 redirect to /elero, so navigating to the device root always lands on the Elero blind manager UI.

Update example.yaml, CLAUDE.md, README.md, docs/CONFIGURATION.md and docs/INSTALLATION.md to reflect the new web_server_base: usage and warn against accidentally adding web_server: back.

https://claude.ai/code/session_01Ej94T5T1sykSyvB2RztoSV