### PR TITLE
fix: correct payload index for command byte in cover and light handlers

### DIFF
--- a/components/elero/cover/EleroCover.cpp
+++ b/components/elero/cover/EleroCover.cpp
@@ -94,7 +94,7 @@ bool EleroCover::is_at_target() {
 void EleroCover::handle_commands(uint32_t now) {
   if((now - this->last_command_) > ELERO_DELAY_SEND_PACKETS) {
     if(this->commands_to_send_.size() > 0) {
-      this->command_.payload[4] = this->commands_to_send_.front();
+      this->command_.payload[8] = this->commands_to_send_.front();
       if(this->parent_->send_command(&this->command_)) {
         this->send_packets_++;
         this->send_retries_ = 0;
@@ -275,8 +275,10 @@ void EleroCover::start_movement(CoverOperation dir) {
       }
     break;
     case COVER_OPERATION_IDLE:
-      if (this->commands_to_send_.size() < ELERO_MAX_COMMAND_QUEUE)
-        this->commands_to_send_.push(this->command_stop_);
+      // Clear any pending movement commands so STOP is sent immediately
+      while (!this->commands_to_send_.empty())
+        this->commands_to_send_.pop();
+      this->commands_to_send_.push(this->command_stop_);
     break;
   }
 

--- a/components/elero/light/EleroLight.cpp
+++ b/components/elero/light/EleroLight.cpp
@@ -138,7 +138,7 @@ void EleroLight::loop() {
 void EleroLight::handle_commands(uint32_t now) {
   if ((now - this->last_command_) > ELERO_DELAY_SEND_PACKETS) {
     if (!this->commands_to_send_.empty()) {
-      this->command_.payload[4] = this->commands_to_send_.front();
+      this->command_.payload[8] = this->commands_to_send_.front();
       if (this->parent_->send_command(&this->command_)) {
         this->send_packets_++;
         this->send_retries_ = 0;


### PR DESCRIPTION
The command byte (UP, DOWN, STOP, etc.) was written to cmd->payload[4]
in both EleroCover::handle_commands() and EleroLight::handle_commands().
However, send_command() overwrites msg_tx_[22/23] (= payload[2/3]) with
the crypto code and then calls msg_encode() on the 8-byte block starting
at msg_tx_[22]. The motor reads the command from decoded payload byte 6,
which maps to msg_tx_[28] = cmd->payload[8].

Placing the command byte at payload[4] put it at encoded-block index 2 —
a position the motor never interprets as a command — so every transmitted
command (including STOP) was silently discarded by the motor.

Fix: use payload[8] in both EleroCover and EleroLight, consistent with
the runtime-blind path in Elero::loop() which already used payload[8].

Also clear the pending command queue before enqueuing STOP in
EleroCover::start_movement(COVER_OPERATION_IDLE) so that a user-issued
stop is not delayed behind already-queued movement commands.

https://claude.ai/code/session_01MgVAhejNuWfbHHV3VcJBc6