### PR TITLE
fix: revert payload[8] regression and fix issue #22 — use payload[4] for command byte in all paths

### DIFF
--- a/components/elero/cover/EleroCover.cpp
+++ b/components/elero/cover/EleroCover.cpp
@@ -94,7 +94,7 @@ bool EleroCover::is_at_target() {
 void EleroCover::handle_commands(uint32_t now) {
   if((now - this->last_command_) > ELERO_DELAY_SEND_PACKETS) {
     if(this->commands_to_send_.size() > 0) {
-      this->command_.payload[8] = this->commands_to_send_.front();
+      this->command_.payload[4] = this->commands_to_send_.front();
       if(this->parent_->send_command(&this->command_)) {
         this->send_packets_++;
         this->send_retries_ = 0;

--- a/components/elero/elero.cpp
+++ b/components/elero/elero.cpp
@@ -55,7 +55,7 @@ void Elero::loop() {
       cmd.hop = rb.hop;
       cmd.payload[0] = rb.payload_1;
       cmd.payload[1] = rb.payload_2;
-      cmd.payload[8] = cmd_byte;
+      cmd.payload[4] = cmd_byte;
       if (this->send_command(&cmd)) {
         rb.command_queue.pop();
         rb.cmd_counter++;

--- a/components/elero/light/EleroLight.cpp
+++ b/components/elero/light/EleroLight.cpp
@@ -138,7 +138,7 @@ void EleroLight::loop() {
 void EleroLight::handle_commands(uint32_t now) {
   if ((now - this->last_command_) > ELERO_DELAY_SEND_PACKETS) {
     if (!this->commands_to_send_.empty()) {
-      this->command_.payload[8] = this->commands_to_send_.front();
+      this->command_.payload[4] = this->commands_to_send_.front();
       if (this->parent_->send_command(&this->command_)) {
         this->send_packets_++;
         this->send_retries_ = 0;


### PR DESCRIPTION
PR #29 (commit 53415b1) changed EleroCover and EleroLight from payload[4]
to payload[8], incorrectly reasoning that they should match the runtime-blind
path in Elero::loop(). That broke all statically-configured blinds and lights.

Root cause (issue #22): send_command() copies cmd->payload[0..9] into
msg_tx_[20..29], then overwrites msg_tx_[22/23] with the counter-derived
crypto code, then encodes msg_tx_[22..29] (8 bytes). The motor reads the
command from the encoded block at offset 2 = msg_tx_[24] = payload[4].
Using payload[8] writes to msg_tx_[28] (block offset 6), which the motor
never interprets as a command opcode — it silently ignores it.

Fix:
- EleroCover::handle_commands(): payload[8] -> payload[4] (reverts PR #29)
- EleroLight::handle_commands(): payload[8] -> payload[4] (reverts PR #29)
- Elero::loop() runtime blind path: payload[8] -> payload[4] (issue #22)

All three command-dispatch sites now use the correct index, restoring
movement for both statically-configured and runtime-adopted blinds.

https://claude.ai/code/session_0175iLq85C67rwoaAwNB69LZ