### PR TITLE
feat(cover): auto-poll status 5s after open/close duration elapses

### DIFF
--- a/components/elero/cover/EleroCover.cpp
+++ b/components/elero/cover/EleroCover.cpp
@@ -54,6 +54,15 @@ void EleroCover::loop() {
     }
   }
 
+  if(this->post_movement_poll_at_ > 0 && now >= this->post_movement_poll_at_) {
+    this->post_movement_poll_at_ = 0;
+    if (this->commands_to_send_.size() < ELERO_MAX_COMMAND_QUEUE) {
+      ESP_LOGD(TAG, "Post-movement status poll for blind 0x%06x", this->command_.blind_addr);
+      this->commands_to_send_.push(this->command_check_);
+      this->last_poll_ = now - this->poll_offset_;
+    }
+  }
+
   this->handle_commands(now);
 
   if((this->current_operation != COVER_OPERATION_IDLE) && (this->open_duration_ > 0) && (this->close_duration_ > 0)) {
@@ -288,6 +297,15 @@ void EleroCover::start_movement(CoverOperation dir) {
   this->current_operation = dir;
   this->movement_start_ = millis();
   this->last_recompute_time_ = millis();
+
+  if(dir == COVER_OPERATION_OPENING && this->open_duration_ > 0) {
+    this->post_movement_poll_at_ = this->movement_start_ + this->open_duration_ + ELERO_POST_MOVEMENT_POLL_DELAY;
+  } else if(dir == COVER_OPERATION_CLOSING && this->close_duration_ > 0) {
+    this->post_movement_poll_at_ = this->movement_start_ + this->close_duration_ + ELERO_POST_MOVEMENT_POLL_DELAY;
+  } else {
+    this->post_movement_poll_at_ = 0;
+  }
+
   this->publish_state();
 }
 

--- a/components/elero/cover/EleroCover.h
+++ b/components/elero/cover/EleroCover.h
@@ -92,6 +92,7 @@ class EleroCover : public cover::Cover, public Component, public EleroBlindBase 
   uint32_t last_publish_{0};
   uint32_t last_recompute_time_{0};
   uint32_t poll_intvl_{0};
+  uint32_t post_movement_poll_at_{0};
   float target_position_{0};
   bool supports_tilt_{false};
   uint32_t last_seen_ms_{0};

--- a/components/elero/elero.h
+++ b/components/elero/elero.h
@@ -60,6 +60,7 @@ static const uint8_t ELERO_MAX_PACKET_SIZE = 57; // according to FCC documents
 static const uint32_t ELERO_POLL_INTERVAL_MOVING = 2000;  // poll every two seconds while moving
 static const uint32_t ELERO_DELAY_SEND_PACKETS = 50; // 50ms send delay between repeats
 static const uint32_t ELERO_TIMEOUT_MOVEMENT = 120000; // poll for up to two minutes while moving
+static const uint32_t ELERO_POST_MOVEMENT_POLL_DELAY = 5000; // poll 5s after open/close duration elapses
 
 static const uint8_t ELERO_SEND_RETRIES = 3;
 static const uint8_t ELERO_SEND_PACKETS = 2;


### PR DESCRIPTION
When a cover has open_duration or close_duration configured, schedule
a status check command 5 seconds after the movement duration expires.
This ensures Home Assistant receives the correct final state even if
the blind's RF status packet is delayed or lost.

- Add ELERO_POST_MOVEMENT_POLL_DELAY constant (5000 ms) to elero.h
- Add post_movement_poll_at_ member to EleroCover to track the deadline
- start_movement() sets the deadline when starting with a known duration,
  and clears it when stopping (IDLE) or when no duration is configured
- loop() fires the check command once the deadline is reached

https://claude.ai/code/session_014MDUK6vNaAgBYVgx4Sok1n