### PR TITLE
docs: update CLAUDE.md with comprehensive codebase audit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance for AI assistants working in this repository. It des
 
 ## Project Overview
 
-`esphome-elero` is a custom **ESPHome external component** that enables Home Assistant to control Elero wireless motor blinds (rollers, shutters, awnings) via a **CC1101 868 MHz (or 433 MHz) RF transceiver** connected to an ESP32 over SPI.
+`esphome-elero` is a custom **ESPHome external component** that enables Home Assistant to control Elero wireless motor blinds (rollers, shutters, awnings) and lights (dimmers) via a **CC1101 868 MHz (or 433 MHz) RF transceiver** connected to an ESP32 over SPI.
 
 The component is loaded directly from GitHub in an ESPHome YAML configuration:
 
@@ -17,10 +17,17 @@ external_components:
 
 **Key capabilities:**
 - Send open/close/stop/tilt commands to Elero blinds
+- Control Elero wireless lights (on/off and brightness dimming)
 - Receive status feedback (top, bottom, moving, blocked, overheated, etc.)
-- Track cover position based on movement timing
+- Track cover position based on movement timing (dead-reckoning)
+- Post-movement status poll 5 s after travel time elapses to confirm final position
+- Immediate status poll when a physical remote command is detected over RF
 - RSSI signal strength monitoring per blind
 - RF discovery scan to find nearby blinds (web UI and log-based)
+- Runtime blind adoption via web UI (no reflash needed)
+- RF packet dump mode for low-level debugging
+- Realtime log capture accessible via REST API
+- Runtime CC1101 frequency switching
 - Optional web UI served at `http://<device-ip>/elero` for discovery and YAML generation
 
 **Upstream credits:**
@@ -44,13 +51,17 @@ esphome-elero/
 └── components/
     ├── elero/                         # Main hub component
     │   ├── __init__.py                # ESPHome component schema & code-gen (hub)
-    │   ├── elero.h                    # C++ hub class header
-    │   ├── elero.cpp                  # C++ RF protocol implementation (~625 lines)
+    │   ├── elero.h                    # C++ hub class header (~329 lines)
+    │   ├── elero.cpp                  # C++ RF protocol implementation (~967 lines)
     │   ├── cc1101.h                   # CC1101 register map & command strobes
     │   ├── cover/                     # Cover (blind) platform
     │   │   ├── __init__.py            # Cover schema & code-gen
     │   │   ├── EleroCover.h           # Cover class header
-    │   │   └── EleroCover.cpp         # Cover logic, position tracking (~307 lines)
+    │   │   └── EleroCover.cpp         # Cover logic, position tracking (~349 lines)
+    │   ├── light/                     # Light (dimmer) platform
+    │   │   ├── __init__.py            # Light schema & code-gen
+    │   │   ├── EleroLight.h           # Light class header
+    │   │   └── EleroLight.cpp         # Light logic, dimming (~225 lines)
     │   ├── button/                    # Scan button platform
     │   │   ├── __init__.py
     │   │   ├── elero_button.h
@@ -61,9 +72,17 @@ esphome-elero/
     │       └── __init__.py
     └── elero_web/                     # Optional web UI component
         ├── __init__.py
-        ├── elero_web_server.h
-        ├── elero_web_server.cpp       # REST API + CORS (~273 lines)
-        └── elero_web_ui.h             # Inline web UI HTML/JS
+        ├── elero_web_server.h         # Web server header
+        ├── elero_web_server.cpp       # REST API + CORS (~878 lines)
+        ├── elero_web_ui.h             # Inline web UI HTML/JS
+        ├── frontend/                  # Build-time web UI source
+        │   ├── index.html
+        │   ├── src/main.js
+        │   └── vite.config.js
+        └── switch/                    # Web UI enable/disable switch sub-platform
+            ├── __init__.py
+            ├── elero_web_switch.h
+            └── elero_web_switch.cpp
 ```
 
 ---
@@ -85,9 +104,10 @@ esphome-elero/
 
 ```
 Elero (hub, SPIDevice + Component)
-├── EleroBlindBase (abstract interface)
-│   ├── EleroCover (cover::Cover + Component + EleroBlindBase)
-│   └── EleroLight (light::LightOutput + Component + EleroBlindBase)
+├── EleroBlindBase (abstract interface for covers)
+│   └── EleroCover (cover::Cover + Component + EleroBlindBase)
+├── EleroLightBase (abstract interface for lights)
+│   └── EleroLight (light::LightOutput + Component + EleroLightBase)
 ├── EleroScanButton (button::Button + Component)
 ├── sensor::Sensor (RSSI, registered per blind address)
 ├── text_sensor::TextSensor (status, registered per blind address)
@@ -96,14 +116,17 @@ Elero (hub, SPIDevice + Component)
 └── Auto-registered sensors/text sensors per cover (optional)
 ```
 
-The `EleroBlindBase` abstract class decouples the hub (`Elero`) from the cover implementation so `elero.h` never needs to `#include` the cover header. All communication between hub and covers goes through virtual methods.
+The `EleroBlindBase` and `EleroLightBase` abstract classes decouple the hub (`Elero`) from the cover/light implementations so `elero.h` never needs to `#include` the cover or light headers. All communication between hub and entities goes through virtual methods.
 
 ### Data flow
 
 1. `Elero::setup()` configures CC1101 registers over SPI and attaches a GPIO interrupt on `gdo0_pin`.
 2. When the CC1101 signals a received packet (GDO0 interrupt), `Elero::interrupt()` sets `received_ = true`.
-3. `Elero::loop()` detects `received_`, reads the FIFO, decodes and decrypts the packet, then dispatches the state to the matching `EleroBlindBase` via `set_rx_state()`.
+3. `Elero::loop()` detects `received_`, reads the FIFO, decodes and decrypts the packet, then:
+   - If it is a **status packet**, dispatches the state to the matching `EleroBlindBase` / `EleroLightBase` via `set_rx_state()`.
+   - If it is a **command packet** from a physical remote, calls `schedule_immediate_poll()` on the targeted device so the hub can observe the new state quickly.
 4. `EleroCover::loop()` handles polling timers, position recomputation, and drains the command queue by calling `parent_->send_command()`.
+5. `EleroLight::loop()` handles dimming timers and drains its command queue similarly.
 
 ---
 
@@ -116,10 +139,17 @@ The `EleroBlindBase` abstract class decouples the hub (`Elero`) from the cover i
 
 Critical public API:
 - `register_cover(EleroBlindBase*)` — called by each `EleroCover` at setup
+- `register_light(EleroLightBase*)` — called by each `EleroLight` at setup
 - `send_command(t_elero_command*)` — encodes, encrypts, and transmits a command
-- `start_scan()` / `stop_scan()` — toggle RF discovery mode
+- `start_scan()` / `stop_scan()` / `is_scanning()` — toggle RF discovery mode
+- `get_discovered_blinds()` / `get_discovered_count()` — discovered device info
+- `adopt_blind(uint32_t addr)` — promote a discovered blind into a runtime-managed blind
+- `remove_runtime_blind(uint32_t addr)` — drop a runtime-adopted blind
+- `send_runtime_command(uint32_t addr, uint8_t cmd)` — send a command to a runtime blind
 - `register_rssi_sensor(uint32_t addr, sensor::Sensor*)` — link RSSI sensor to a blind address
 - `register_text_sensor(uint32_t addr, text_sensor::TextSensor*)` — link text sensor to a blind address
+- `start_packet_dump()` / `stop_packet_dump()` — toggle raw RF packet capture (ring buffer)
+- `append_log(level, tag, msg)` / `get_log_entries()` — web UI log capture helpers
 - `interrupt(Elero *arg)` — static ISR, sets `received_` flag
 
 Key constants (defined in `elero.h`):
@@ -133,30 +163,120 @@ Key constants (defined in `elero.h`):
 | `ELERO_SEND_PACKETS` | 2 | Packets sent per command |
 | `ELERO_DELAY_SEND_PACKETS` | 50 ms | Delay between packet repeats |
 | `ELERO_MAX_DISCOVERED` | 20 | Max blinds tracked in scan mode |
+| `ELERO_MAX_COMMAND_QUEUE` | 10 | Max queued commands per blind (OOM guard) |
 
-State constants (`ELERO_STATE_*`): `UNKNOWN`, `TOP`, `BOTTOM`, `INTERMEDIATE`, `TILT`, `BLOCKING`, `OVERHEATED`, `TIMEOUT`, `START_MOVING_UP`, `START_MOVING_DOWN`, `MOVING_UP`, `MOVING_DOWN`, `STOPPED`, `TOP_TILT`, `BOTTOM_TILT`
+State constants (`ELERO_STATE_*`):
+
+| Constant | Value | Meaning |
+|---|---|---|
+| `ELERO_STATE_UNKNOWN` | 0x00 | Unknown |
+| `ELERO_STATE_TOP` | 0x01 | Fully open |
+| `ELERO_STATE_BOTTOM` | 0x02 | Fully closed |
+| `ELERO_STATE_INTERMEDIATE` | 0x03 | Partial position |
+| `ELERO_STATE_TILT` | 0x04 | Tilted |
+| `ELERO_STATE_BLOCKING` | 0x05 | Blocked (error) |
+| `ELERO_STATE_OVERHEATED` | 0x06 | Overheated (error) |
+| `ELERO_STATE_TIMEOUT` | 0x07 | Timeout (error) |
+| `ELERO_STATE_START_MOVING_UP` | 0x08 | Starting to move up |
+| `ELERO_STATE_START_MOVING_DOWN` | 0x09 | Starting to move down |
+| `ELERO_STATE_MOVING_UP` | 0x0a | Moving up |
+| `ELERO_STATE_MOVING_DOWN` | 0x0b | Moving down |
+| `ELERO_STATE_STOPPED` | 0x0d | Stopped at intermediate position |
+| `ELERO_STATE_TOP_TILT` | 0x0e | Open and tilted |
+| `ELERO_STATE_BOTTOM_TILT` | 0x0f | Closed and tilted (also maps to light OFF) |
+| `ELERO_STATE_ON` | 0x10 | Light on |
+
+Key internal data structures:
+
+**`t_elero_command`** — 29-byte command packet to be encrypted and transmitted:
+```cpp
+struct t_elero_command {
+  uint8_t  counter;          // Message counter (1–255, increments per command)
+  uint32_t blind_addr;       // Target blind RF address
+  uint32_t remote_addr;      // Simulated remote address
+  uint8_t  channel;
+  uint8_t  pck_inf[2];       // Packet info bytes (typ, typ2) — typically 0x6a, 0x00
+  uint8_t  hop;              // Hop count — typically 0x0a
+  uint8_t  payload[10];      // Command payload (payload[4] = command byte)
+};
+```
+
+**`DiscoveredBlind`** — blind found during RF scan:
+```cpp
+struct DiscoveredBlind {
+  uint32_t blind_address, remote_address;
+  uint8_t  channel, pck_inf[2], hop;
+  uint8_t  payload_1, payload_2;
+  float    rssi;
+  uint32_t last_seen;           // millis() timestamp
+  uint8_t  last_state;
+  uint16_t times_seen;
+  bool     params_from_command; // true = from 6a/69 cmd pkt (preferred), false = from CA/C9 status
+};
+```
+
+**`RuntimeBlind`** — blind adopted at runtime via web UI (no firmware reflash):
+```cpp
+struct RuntimeBlind {
+  uint32_t blind_address, remote_address;
+  uint8_t  channel, pck_inf[2], hop;
+  uint8_t  payload_1, payload_2;
+  std::string name;
+  uint32_t open_duration_ms, close_duration_ms, poll_intvl_ms;
+  uint32_t last_seen_ms;
+  float    last_rssi;
+  uint8_t  last_state;
+  uint8_t  cmd_counter;
+  std::queue<uint8_t> command_queue;
+};
+```
+
+**`RawPacket`** — single captured RF packet (packet dump mode, ring buffer of 50):
+```cpp
+struct RawPacket {
+  uint32_t timestamp_ms;
+  uint8_t  fifo_len;
+  uint8_t  data[64];        // Raw CC1101 FIFO bytes
+  bool     valid;
+  char     reject_reason[32];
+};
+```
+
+**`LogEntry`** — captured log message (circular buffer for web UI):
+```cpp
+struct LogEntry {
+  uint32_t timestamp_ms;
+  uint8_t  level;
+  char     tag[24];
+  char     message[160];
+};
+```
 
 ### `components/elero/cover/EleroCover.h` / `EleroCover.cpp`
 
 **Class:** `EleroCover : public cover::Cover, public Component, public EleroBlindBase`
 
 Key behaviors:
-- Maintains an internal `std::queue<uint8_t> commands_to_send_` for reliable delivery
+- Maintains an internal `std::queue<uint8_t> commands_to_send_` (capped at `ELERO_MAX_COMMAND_QUEUE`) for reliable delivery
 - Polls blind status at a configurable interval (`poll_intvl_`, default 5 min); while moving, polls every `ELERO_POLL_INTERVAL_MOVING` (2 s)
+- **Post-movement poll**: 5 s after `open_duration_` / `close_duration_` elapses, sends an extra status check to confirm final state
+- **Immediate poll on remote**: when the hub detects a physical remote command for this blind, `schedule_immediate_poll()` queues a CHECK command within ~50 ms
 - Tracks cover `position` (0.0–1.0) by dead-reckoning against `open_duration_` / `close_duration_` timestamps
 - Supports tilt as a separate operation via `command_tilt_`
-- Staggered poll offsets (`poll_offset_`) prevent all covers from polling simultaneously
+- Staggered poll offsets (`poll_offset_`, auto-incremented by 5 s per cover) prevent all covers from polling simultaneously
 - Auto-generates RSSI and status text sensors unless `auto_sensors: false` is set
 
 ### `components/elero/light/EleroLight.h` / `EleroLight.cpp`
 
-**Class:** `EleroLight : public light::LightOutput, public Component, public EleroBlindBase`
+**Class:** `EleroLight : public light::LightOutput, public Component, public EleroLightBase`
 
 Key behaviors:
-- Implements on/off and brightness control for Elero wireless lights (dimmers)
-- `dim_duration` parameter controls brightness range: `0s` = on/off only, `>0` = brightness control
-- Shares the same RF protocol and command structure as covers
-- Supports optional status checking via `command_check`
+- Implements on/off and optional brightness control for Elero wireless lights (dimmers)
+- `dim_duration: 0s` → `ON_OFF` color mode only (no brightness slider)
+- `dim_duration: Xs` → `BRIGHTNESS` color mode; X is the time to ramp from 0 % to 100 % using timed `dim_up` / `dim_down` + `stop` commands
+- Uses an `ignore_write_state_` flag to break feedback loops when `set_rx_state()` updates the internal state
+- Shares the same RF protocol and `t_elero_command` structure as covers
+- Polls blind status when `command_check: 0x00` is set (optional; omit for lights that do not respond)
 
 ### `components/elero_web/elero_web_server.h` / `elero_web_server.cpp`
 
@@ -167,10 +287,12 @@ Key behaviors:
 - Hosts the web UI at `http://<device-ip>/elero`
 - Exposes REST API for RF scanning, blind discovery, control, and runtime diagnostics
 - `EleroWebSwitch` allows runtime enable/disable of all `/elero` endpoints (returns 503 when disabled)
+- All endpoints include `Access-Control-Allow-Origin: *` CORS headers
+- User-controlled strings (blind names) are JSON-escaped before embedding in responses
 
 ### REST API Endpoints
 
-All endpoints are served at `http://<device-ip>/elero` and support CORS. A 503 response is returned if the optional `elero_web` switch is disabled.
+All endpoints are served at `http://<device-ip>/elero`. A 503 response is returned if the optional `elero_web` switch is disabled.
 
 **Core endpoints:**
 
@@ -192,14 +314,14 @@ All endpoints are served at `http://<device-ip>/elero` and support CORS. A 503 r
 |---|---|---|
 | `/elero/api/covers/0xADDRESS/command` | POST | Send command to cover/light (body: `{"cmd": "up"\|"down"\|"stop"\|"tilt"}`) |
 | `/elero/api/covers/0xADDRESS/settings` | POST | Update cover settings at runtime (body: JSON with timing/poll settings) |
-| `/elero/api/discovered/0xADDRESS/adopt` | POST | Adopt a discovered blind into configured covers |
+| `/elero/api/discovered/0xADDRESS/adopt` | POST | Adopt a discovered blind into runtime-managed blinds |
 
 **Diagnostics:**
 
 | Endpoint | Method | Description |
 |---|---|---|
 | `/elero/api/frequency` | GET | Current CC1101 frequency settings |
-| `/elero/api/frequency/set` | POST | Update CC1101 frequency (body: `{"freq0": 0x7a, "freq1": 0x71, "freq2": 0x21}`) |
+| `/elero/api/frequency/set` | POST | Update CC1101 frequency at runtime (body: `{"freq0": 0x7a, "freq1": 0x71, "freq2": 0x21}`) |
 | `/elero/api/logs` | GET | Recent log entries (supports `since` query parameter) |
 | `/elero/api/logs/clear` | POST | Clear captured logs |
 | `/elero/api/logs/capture/start` | POST | Start capturing logs |
@@ -223,6 +345,28 @@ All endpoints are served at `http://<device-ip>/elero` and support CORS. A 503 r
 | 200 | Success |
 | 409 | Conflict (e.g., trying to start scan when one is already running) |
 | 503 | Service Unavailable (returned when web UI is disabled via switch) |
+
+---
+
+## RF Protocol Notes
+
+### Command byte locations
+
+Commands are placed at `payload[4]` inside `t_elero_command` (index 4 of the 10-byte payload). Default command bytes:
+
+| Command | Byte |
+|---|---|
+| UP | `0x20` |
+| DOWN | `0x40` |
+| STOP | `0x10` |
+| CHECK (poll) | `0x00` |
+| TILT | `0x24` |
+
+### Encryption
+
+- Encryption is counter-based: `code = 0x00 - (counter * 0x708f) & 0xffff`
+- The hub recognises both **command packets** (type `0x6a`/`0x69`) from physical remotes and **status packets** (type `0xCA`/`0xC9`) from blinds
+- Discovery preferentially uses parameters extracted from command packets over status packets (`params_from_command` flag)
 
 ---
 
@@ -259,6 +403,8 @@ parent = await cg.get_variable(config[CONF_ELERO_ID])
 cg.add(var.set_elero_parent(parent))
 ```
 
+The cover `__init__.py` validates that `open_duration` and `close_duration` must both be set or both be `0s` — it is invalid to set only one.
+
 ---
 
 ## Configuration Reference (Summary)
@@ -292,14 +438,24 @@ Required parameters:
 - `remote_address` — 3-byte hex address of the remote control paired with the blind
 
 Optional parameters (with defaults):
-- `poll_interval` (default `5min`, or `never`) — how often to query blind status
-- `open_duration` / `close_duration` (default `0s`) — enables position tracking
-- `supports_tilt` (default `false`)
-- `auto_sensors` (default `true`) — auto-generate RSSI and status text sensors for this cover
-- `payload_1` (default `0x00`), `payload_2` (default `0x04`)
-- `pck_inf1` (default `0x6a`), `pck_inf2` (default `0x00`)
-- `hop` (default `0x0a`)
-- `command_up/down/stop/check/tilt` — override RF command bytes if non-standard
+
+| Parameter | Default | Notes |
+|---|---|---|
+| `poll_interval` | `5min` | Use `never` to disable polling |
+| `open_duration` | `0s` | Must set both or neither |
+| `close_duration` | `0s` | Must set both or neither |
+| `supports_tilt` | `false` | |
+| `auto_sensors` | `true` | Auto-generate RSSI + status sensors |
+| `payload_1` | `0x00` | |
+| `payload_2` | `0x04` | |
+| `pck_inf1` | `0x6a` | |
+| `pck_inf2` | `0x00` | |
+| `hop` | `0x0a` | |
+| `command_up` | `0x20` | Override RF command bytes |
+| `command_down` | `0x40` | |
+| `command_stop` | `0x10` | |
+| `command_check` | `0x00` | |
+| `command_tilt` | `0x24` | |
 
 ### Light (`light: platform: elero`)
 
@@ -309,11 +465,21 @@ Required parameters:
 - `remote_address` — 3-byte hex address of the remote control paired with the light
 
 Optional parameters (with defaults):
-- `dim_duration` (default `0s`) — time for dimming from 0% to 100%; `0s` = on/off only, `>0` = brightness control
-- `payload_1` (default `0x00`), `payload_2` (default `0x04`)
-- `pck_inf1` (default `0x6a`), `pck_inf2` (default `0x00`)
-- `hop` (default `0x0a`)
-- `command_on/off/dim_up/dim_down/stop/check` — override RF command bytes if non-standard
+
+| Parameter | Default | Notes |
+|---|---|---|
+| `dim_duration` | `0s` | `0s` = on/off only; `>0s` = brightness control (ramp time 0→100%) |
+| `payload_1` | `0x00` | |
+| `payload_2` | `0x04` | |
+| `pck_inf1` | `0x6a` | |
+| `pck_inf2` | `0x00` | |
+| `hop` | `0x0a` | |
+| `command_on` | `0x20` | |
+| `command_off` | `0x40` | |
+| `command_dim_up` | `0x20` | |
+| `command_dim_down` | `0x40` | |
+| `command_stop` | `0x10` | |
+| `command_check` | `0x00` | |
 
 ### Sensors
 
@@ -326,7 +492,7 @@ sensor:
 text_sensor:
   - platform: elero
     blind_address: 0xa831e5
-    name: "Blind Status"      # Values: see state constants above
+    name: "Blind Status"      # Values: see ELERO_STATE_* constants
 ```
 
 ### Buttons (RF scan)
@@ -340,6 +506,8 @@ button:
     name: "Stop Scan"
     scan_start: false
 ```
+
+Buttons also support a `light_id` parameter to send a direct command byte (default `0x44`) to a specific light entity instead of operating the scan.
 
 ### Web UI (`elero_web`)
 
@@ -420,6 +588,8 @@ The typical workflow for a new installation:
 5. Discovered blinds appear in the web UI with addresses pre-filled
 6. Download the generated YAML snippet and add it to your config
 
+Alternatively, blinds can be **adopted at runtime** via the web UI (`/elero/api/discovered/0xADDRESS/adopt`) without reflashing — they are stored as `RuntimeBlind` entries in the hub.
+
 ---
 
 ## Testing
@@ -430,23 +600,29 @@ There are no automated tests in this repository. Validation is done manually on 
 2. Use the RF scan to confirm blind discovery
 3. Test each cover entity (open, close, stop) from Home Assistant
 4. Verify RSSI and status text sensors update correctly
+5. For lights: verify on/off, and brightness if `dim_duration > 0s`
+6. For diagnostics: use `/elero/api/dump/start` + `/elero/api/packets` to verify raw RF reception
 
 ---
 
 ## Common Pitfalls
 
-- **Wrong frequency**: Most European Elero motors use 868.35 MHz (`freq0=0x7a`). Some use 868.95 MHz (`freq0=0xc0`). If discovery finds nothing, try the alternate frequency.
+- **Wrong frequency**: Most European Elero motors use 868.35 MHz (`freq0=0x7a`). Some use 868.95 MHz (`freq0=0xc0`). If discovery finds nothing, try the alternate frequency. Frequency can also be changed at runtime via `/elero/api/frequency/set` without reflashing.
 - **SPI conflicts**: The CC1101 CS pin must not be shared with any other SPI device.
 - **Using `web_server:` instead of `web_server_base:`**: Adding `web_server:` to your YAML re-enables the default ESPHome entity UI at `/`. Use `web_server_base:` (or rely on its auto-load via `elero_web`) to serve only the Elero UI at `/elero`. Navigating to `/` will redirect automatically to `/elero`.
-- **Position tracking**: Leave `open_duration` and `close_duration` at `0s` if you only need open/close without position — setting incorrect durations causes wrong position estimates.
+- **Position tracking**: Leave `open_duration` and `close_duration` at `0s` if you only need open/close without position — setting incorrect durations causes wrong position estimates. Both must be set together (one without the other is a schema validation error).
 - **Poll interval `never`**: Set `poll_interval: never` for blinds that reliably push state updates (avoids unnecessary RF traffic). Internally this maps to `uint32_t` max (4 294 967 295 ms).
+- **Light dimming with `dim_duration: 0s`**: Results in `ON_OFF` color mode — no brightness slider is exposed to Home Assistant. Set a non-zero value only for dimmable receivers.
+- **Command queue cap**: Each cover/light allows at most `ELERO_MAX_COMMAND_QUEUE` (10) queued commands to guard against OOM. Commands sent when the queue is full are silently dropped — avoid flooding the queue.
+- **EleroLight feedback loop**: The `ignore_write_state_` flag prevents the light from re-sending a command when its own `set_rx_state()` updates the light's internal state. Do not remove this guard.
 
 ---
 
 ## Contributing
 
 - Follow the existing naming conventions for C++ and Python code.
-- Keep the `EleroBlindBase` interface minimal — the hub should not depend on cover internals.
+- Keep the `EleroBlindBase` and `EleroLightBase` interfaces minimal — the hub should not depend on cover or light internals.
 - Test changes on real hardware before opening a pull request.
 - Document new configuration parameters in both `README.md` and `docs/CONFIGURATION.md`.
 - The primary development branch convention used by automation is `claude/<session-id>`.
+- There is no dedicated `stable` branch — `master` is the stable reference branch.


### PR DESCRIPTION
- Correct file tree: add light/, elero_web/switch/, elero_web/frontend/ directories
- Fix approximate line counts (elero.cpp ~967, EleroCover.cpp ~349, elero_web_server.cpp ~878)
- Split EleroBlindBase / EleroLightBase into separate abstract interfaces in hierarchy
- Document all hub public API methods: register_light, adopt_blind, remove_runtime_blind,
  send_runtime_command, start/stop_packet_dump, append_log/get_log_entries, is_scanning,
  get_discovered_blinds/count
- Add ELERO_MAX_COMMAND_QUEUE constant and ELERO_STATE_ON for lights
- Document all internal structs: t_elero_command, DiscoveredBlind, RuntimeBlind,
  RawPacket, LogEntry
- Add RF protocol section (command byte position, encryption algorithm, packet types)
- Document post-movement polling, immediate poll on remote, runtime blind adoption
- Expand light section: feedback loop guard, dim_duration modes, command byte defaults
- Expand button section: light_id parameter
- Expand pitfalls: frequency runtime switching, queue cap, light feedback loop guard
- Note master is the stable reference branch (no dedicated stable branch exists)
- Reformat optional parameter tables for covers and lights for readability

https://claude.ai/code/session_01WTQidqopbuKeHo3erE91Pu