### PR TITLE
Fix Elero light state reporting to distinguish "off" from "bottom_tilt"

### DIFF
--- a/components/elero/elero.cpp
+++ b/components/elero/elero.cpp
@@ -18,7 +18,7 @@ static const char *TAG = "elero";
 static const uint8_t flash_table_encode[] = {0x08, 0x02, 0x0d, 0x01, 0x0f, 0x0e, 0x07, 0x05, 0x09, 0x0c, 0x00, 0x0a, 0x03, 0x04, 0x0b, 0x06};
 static const uint8_t flash_table_decode[] = {0x0a, 0x03, 0x01, 0x0c, 0x0d, 0x07, 0x0f, 0x06, 0x00, 0x08, 0x0b, 0x0e, 0x09, 0x02, 0x05, 0x04};
 
-const char *elero_state_to_string(uint8_t state) {
+const char *elero_state_to_string(uint8_t state, bool is_light) {
   switch (state) {
     case ELERO_STATE_TOP: return "top";
     case ELERO_STATE_BOTTOM: return "bottom";
@@ -33,7 +33,8 @@ const char *elero_state_to_string(uint8_t state) {
     case ELERO_STATE_MOVING_DOWN: return "moving_down";
     case ELERO_STATE_STOPPED: return "stopped";
     case ELERO_STATE_TOP_TILT: return "top_tilt";
-    case ELERO_STATE_BOTTOM_TILT: return "bottom_tilt"; // also ELERO_STATE_OFF (0x0f)
+    case ELERO_STATE_BOTTOM_TILT: // also ELERO_STATE_OFF (0x0f)
+      return is_light ? "off" : "bottom_tilt";
     case ELERO_STATE_ON: return "on";
     default: return "unknown";
   }
@@ -656,7 +657,8 @@ void Elero::interpret_msg() {
     {
       auto text_it = this->address_to_text_sensor_.find(src);
       if (text_it != this->address_to_text_sensor_.end()) {
-        text_it->second->publish_state(elero_state_to_string(payload[6]));
+        bool light = this->is_light_configured(src);
+        text_it->second->publish_state(elero_state_to_string(payload[6], light));
       }
     }
 #endif

--- a/components/elero/elero.h
+++ b/components/elero/elero.h
@@ -136,7 +136,7 @@ struct RuntimeBlind {
   std::queue<uint8_t> command_queue;
 };
 
-const char *elero_state_to_string(uint8_t state);
+const char *elero_state_to_string(uint8_t state, bool is_light = false);
 
 /// Abstract base class for light actuators registered with the Elero hub.
 /// EleroLight inherits from this so the hub never needs the light header.
@@ -238,6 +238,9 @@ class Elero : public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARIT
     return address_to_cover_mapping_.find(address) != address_to_cover_mapping_.end();
   }
   const std::map<uint32_t, EleroBlindBase *> &get_configured_covers() const { return address_to_cover_mapping_; }
+  bool is_light_configured(uint32_t address) const {
+    return address_to_light_mapping_.find(address) != address_to_light_mapping_.end();
+  }
 
   // Packet dump mode: capture every received FIFO read into a ring buffer
   void start_packet_dump();


### PR DESCRIPTION
## Summary
This PR fixes state reporting for Elero light actuators by distinguishing between the "off" state and the "bottom_tilt" state, which share the same state code (0x0f) in the protocol.

## Key Changes
- Modified `elero_state_to_string()` function to accept an `is_light` parameter that determines whether state 0x0f should be reported as "off" (for lights) or "bottom_tilt" (for blinds)
- Added `is_light_configured()` method to the Elero class to check if a device address is configured as a light
- Updated the message interpretation logic to pass the light configuration status when converting device states to strings
- Added default parameter value (`is_light = false`) to maintain backward compatibility

## Implementation Details
The Elero protocol uses the same state code (0x0f) for both `ELERO_STATE_BOTTOM_TILT` (blinds) and `ELERO_STATE_OFF` (lights). This change allows the state conversion function to return the appropriate string representation based on the device type, ensuring accurate state reporting in the text sensor for light actuators.

https://claude.ai/code/session_01F9Y7RECdqzDj2Z9U6TMTw6