### PR TITLE
Add error handling and queue size validation to Elero component

### DIFF
--- a/components/elero/cover/EleroCover.h
+++ b/components/elero/cover/EleroCover.h
@@ -61,7 +61,10 @@ class EleroCover : public cover::Cover, public Component, public EleroBlindBase 
   uint32_t get_close_duration_ms() const override { return this->close_duration_; }
   bool get_supports_tilt() const override { return this->supports_tilt_; }
   // EleroBlindBase web API commands
-  void enqueue_command(uint8_t cmd_byte) override { this->commands_to_send_.push(cmd_byte); }
+  void enqueue_command(uint8_t cmd_byte) override {
+    if (this->commands_to_send_.size() < ELERO_MAX_COMMAND_QUEUE)
+      this->commands_to_send_.push(cmd_byte);
+  }
   void apply_runtime_settings(uint32_t open_dur_ms, uint32_t close_dur_ms,
                               uint32_t poll_intvl_ms) override {
     this->open_duration_ = open_dur_ms;

--- a/components/elero/elero.cpp
+++ b/components/elero/elero.cpp
@@ -65,7 +65,7 @@ void Elero::loop() {
         if (this->send_command(&cmd)) {
           rb.command_queue.pop();
           rb.cmd_counter++;
-          if (rb.cmd_counter > 255) rb.cmd_counter = 1;
+          if (rb.cmd_counter == 0) rb.cmd_counter = 1;
         }
       }
     }
@@ -925,9 +925,10 @@ bool Elero::adopt_blind(const DiscoveredBlind &discovered, const std::string &na
   rb.last_seen_ms = discovered.last_seen;
   rb.last_rssi = discovered.rssi;
   rb.last_state = discovered.last_state;
+  const std::string adopted_name = rb.name;
   this->runtime_blinds_.insert({discovered.blind_address, std::move(rb)});
   ESP_LOGI(TAG, "Adopted runtime blind 0x%06x as \"%s\"",
-           discovered.blind_address, rb.name.c_str());
+           discovered.blind_address, adopted_name.c_str());
   return true;
 }
 

--- a/components/elero/elero_log.cpp
+++ b/components/elero/elero_log.cpp
@@ -125,7 +125,11 @@ void EleroEventLog::write_header_() {
   if (this->file_ == nullptr)
     return;
   fseek(this->file_, 0, SEEK_SET);
-  fwrite(&this->header_, sizeof(PersistentLogHeader), 1, this->file_);
+  if (fwrite(&this->header_, sizeof(PersistentLogHeader), 1, this->file_) != 1) {
+    ESP_LOGE(TAG, "Failed to write event log header");
+    this->ready_ = false;
+    return;
+  }
   fflush(this->file_);
 }
 
@@ -133,7 +137,10 @@ void EleroEventLog::read_header_() {
   if (this->file_ == nullptr)
     return;
   fseek(this->file_, 0, SEEK_SET);
-  fread(&this->header_, sizeof(PersistentLogHeader), 1, this->file_);
+  if (fread(&this->header_, sizeof(PersistentLogHeader), 1, this->file_) != 1) {
+    ESP_LOGE(TAG, "Failed to read event log header");
+    memset(&this->header_, 0, sizeof(this->header_));
+  }
 }
 
 void EleroEventLog::write_entry_(uint16_t idx, const PersistentLogEntry &entry) {
@@ -141,7 +148,9 @@ void EleroEventLog::write_entry_(uint16_t idx, const PersistentLogEntry &entry) 
     return;
   long offset = sizeof(PersistentLogHeader) + (long)idx * sizeof(PersistentLogEntry);
   fseek(this->file_, offset, SEEK_SET);
-  fwrite(&entry, sizeof(PersistentLogEntry), 1, this->file_);
+  if (fwrite(&entry, sizeof(PersistentLogEntry), 1, this->file_) != 1) {
+    ESP_LOGW(TAG, "Failed to write event log entry at index %u", idx);
+  }
   fflush(this->file_);
 }
 
@@ -151,7 +160,10 @@ PersistentLogEntry EleroEventLog::read_entry_(uint16_t idx) const {
     return entry;
   long offset = sizeof(PersistentLogHeader) + (long)idx * sizeof(PersistentLogEntry);
   fseek(this->file_, offset, SEEK_SET);
-  fread(&entry, sizeof(PersistentLogEntry), 1, this->file_);
+  if (fread(&entry, sizeof(PersistentLogEntry), 1, this->file_) != 1) {
+    ESP_LOGW(TAG, "Failed to read event log entry at index %u", idx);
+    memset(&entry, 0, sizeof(entry));
+  }
   return entry;
 }
 
@@ -206,9 +218,16 @@ std::vector<PersistentLogEntry> EleroEventLog::read_all() const {
 }
 
 std::vector<PersistentLogEntry> EleroEventLog::read_since(uint32_t since_seq) const {
-  std::vector<PersistentLogEntry> all = this->read_all();
   std::vector<PersistentLogEntry> result;
-  for (const auto &entry : all) {
+  if (!this->ready_)
+    return result;
+
+  uint16_t count = this->get_entry_count();
+  uint16_t start = (this->header_.total_written <= this->header_.max_entries)
+                   ? 0 : this->header_.write_idx;
+  for (uint16_t i = 0; i < count; i++) {
+    uint16_t idx = (start + i) % this->header_.max_entries;
+    PersistentLogEntry entry = this->read_entry_(idx);
     if (entry.sequence > since_seq) {
       result.push_back(entry);
     }

--- a/components/elero/light/EleroLight.h
+++ b/components/elero/light/EleroLight.h
@@ -27,7 +27,10 @@ class EleroLight : public light::LightOutput, public Component, public EleroLigh
     this->last_seen_ms_ = ms;
     this->last_rssi_ = rssi;
   }
-  void enqueue_command(uint8_t cmd_byte) override { this->commands_to_send_.push(cmd_byte); }
+  void enqueue_command(uint8_t cmd_byte) override {
+    if (this->commands_to_send_.size() < ELERO_MAX_COMMAND_QUEUE)
+      this->commands_to_send_.push(cmd_byte);
+  }
   void schedule_immediate_poll() override;
 
   // RF parameter setters

--- a/components/elero/sensor/__init__.py
+++ b/components/elero/sensor/__init__.py
@@ -23,7 +23,7 @@ CONFIG_SCHEMA = (
     .extend(
         {
             cv.GenerateID(CONF_ELERO_ID): cv.use_id(elero),
-            cv.Required(CONF_BLIND_ADDRESS): cv.hex_int_range(min=0x0, max=0xFFFFFF),
+            cv.Required(CONF_BLIND_ADDRESS): cv.hex_int_range(min=0x0, max=0xffffff),
         }
     )
 )

--- a/components/elero/text_sensor/__init__.py
+++ b/components/elero/text_sensor/__init__.py
@@ -13,7 +13,7 @@ CONFIG_SCHEMA = (
     .extend(
         {
             cv.GenerateID(CONF_ELERO_ID): cv.use_id(elero),
-            cv.Required(CONF_BLIND_ADDRESS): cv.hex_int_range(min=0x0, max=0xFFFFFF),
+            cv.Required(CONF_BLIND_ADDRESS): cv.hex_int_range(min=0x0, max=0xffffff),
         }
     )
 )


### PR DESCRIPTION
## Summary
This PR adds robust error handling for file I/O operations in the event log and implements queue size validation for command queues across the Elero component. Additionally, it fixes a counter overflow bug and improves code safety.

## Key Changes

- **Event Log Error Handling**: Added return value checks for all `fread()` and `fwrite()` operations in `elero_log.cpp`:
  - Header write failures now set `ready_` flag to false and log errors
  - Header and entry read failures are logged as warnings with graceful fallback (zero-initialization)
  - Entry write failures are logged as warnings

- **Command Queue Validation**: Added size checks before enqueueing commands in both `EleroCover` and `EleroLight` to prevent queue overflow:
  - Commands are only enqueued if queue size is below `ELERO_MAX_COMMAND_QUEUE`

- **Counter Overflow Fix**: Changed counter reset condition in `elero.cpp` from `> 255` to `== 0` to properly handle the counter lifecycle

- **Adoption Bug Fix**: Fixed use-after-move bug in `adopt_blind()` by storing the adopted name before moving the runtime blind object

- **Code Style**: Normalized hex constants to lowercase (`0xFFFFFF` → `0xffffff`) in Python configuration files

## Notable Implementation Details

- The event log now gracefully handles I/O failures by zeroing out data structures rather than leaving them in an undefined state
- Queue validation prevents potential buffer overflows from excessive command enqueueing
- The counter fix ensures proper sequence numbering for commands (1-255 range instead of 0-255)

https://claude.ai/code/session_01KFudTPgtoeFfpHhbpZC8pW