### PR TITLE
Make esp_spiffs.h inclusion optional in elero_log.cpp

### DIFF
--- a/components/elero/elero_log.cpp
+++ b/components/elero/elero_log.cpp
@@ -5,7 +5,13 @@
 #include <algorithm>
 
 #ifdef USE_ESP_IDF
+#if __has_include("esp_spiffs.h")
 #include "esp_spiffs.h"
+#elif __has_include(<esp_spiffs.h>)
+#include <esp_spiffs.h>
+#else
+#define ELERO_NO_ESP_SPIFFS
+#endif
 #elif defined(USE_ARDUINO)
 #include "SPIFFS.h"
 #endif
@@ -17,6 +23,12 @@ static const char *const TAG = "elero.log";
 
 bool EleroEventLog::begin(uint16_t max_entries) {
 #ifdef USE_ESP_IDF
+#ifdef ELERO_NO_ESP_SPIFFS
+  // esp_spiffs.h not available — try opening the file directly in case
+  // another component (e.g. ESPHome core) already mounted the filesystem.
+  ESP_LOGW(TAG, "esp_spiffs.h not found at compile time; "
+                "assuming filesystem is already mounted");
+#else
   // Mount SPIFFS if not already mounted (ESP-IDF API)
   esp_vfs_spiffs_conf_t spiffs_conf = {
       .base_path = "/spiffs",
@@ -35,6 +47,7 @@ bool EleroEventLog::begin(uint16_t max_entries) {
   } else {
     ESP_LOGD(TAG, "SPIFFS mounted successfully");
   }
+#endif  // ELERO_NO_ESP_SPIFFS
 #elif defined(USE_ARDUINO) && defined(USE_ESP32)
   // Mount SPIFFS (Arduino API) — true = format on first use
   if (!SPIFFS.begin(true)) {


### PR DESCRIPTION
## Summary
This change makes the `esp_spiffs.h` header inclusion optional for ESP-IDF builds, allowing the code to gracefully handle cases where the header is not available while still attempting to use an already-mounted filesystem.

## Key Changes
- Added conditional compilation checks using `__has_include()` to detect `esp_spiffs.h` availability in both quoted and angle-bracket include forms
- Introduced `ELERO_NO_ESP_SPIFFS` macro to indicate when the header is unavailable
- When `esp_spiffs.h` is not found, the SPIFFS mounting code is skipped with a warning log, assuming the filesystem is already mounted by another component (e.g., ESPHome core)
- Wrapped the SPIFFS initialization block with `#ifdef ELERO_NO_ESP_SPIFFS` guards to conditionally compile the mounting logic

## Implementation Details
- Uses preprocessor `__has_include()` directive for robust header detection across different build configurations
- Maintains backward compatibility: when `esp_spiffs.h` is available, behavior is unchanged
- Provides informative warning message when header is unavailable, helping users understand the fallback behavior
- Allows the component to work in environments where SPIFFS is pre-mounted by other components

https://claude.ai/code/session_01DqCaiTuMqxSRfDBdyrzPvK