### PR TITLE
Replace SPIFFS with LittleFS for persistent event logging

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ external_components:
 - Realtime log capture accessible via REST API
 - Runtime CC1101 frequency switching
 - Optional web UI served at `http://<device-ip>/elero` for discovery and YAML generation
-- Optional persistent event logging (SPIFFS ring buffer) for RF packets, state transitions, and commands
+- Optional persistent event logging (LittleFS ring buffer) for RF packets, state transitions, and commands
 
 **Upstream credits:**
 - Encryption/decryption: [QuadCorei8085/elero_protocol](https://github.com/QuadCorei8085/elero_protocol) (MIT)
@@ -55,7 +55,7 @@ esphome-elero/
     │   ├── elero.h                    # C++ hub class header
     │   ├── elero.cpp                  # C++ RF protocol implementation (~625 lines)
     │   ├── elero_log.h                # Persistent event log header (EleroEventLog)
-    │   ├── elero_log.cpp              # SPIFFS ring buffer implementation
+    │   ├── elero_log.cpp              # LittleFS ring buffer implementation
     │   ├── cc1101.h                   # CC1101 register map & command strobes
     │   ├── cover/                     # Cover (blind) platform
     │   │   ├── __init__.py            # Cover schema & code-gen
@@ -287,12 +287,12 @@ Key behaviors:
 **Namespace:** `esphome::elero`
 
 Key behaviors:
-- SPIFFS-based persistent ring buffer storing 64-byte fixed-size event entries
+- LittleFS-based persistent ring buffer storing 64-byte fixed-size event entries
 - Logs RF received packets, cover state transitions, commands sent, and system events
 - Survives reboots — entries persist on flash storage
 - Header flush batching (every 10 appends) reduces flash wear
 - Enabled via `logging: enable: true` in the hub config; disabled by default
-- File layout: 64-byte header + N × 64-byte entries at `/spiffs/elero_events.bin`
+- File layout: 64-byte header + N × 64-byte entries at `/littlefs/elero_events.bin`
 
 ### `components/elero_web/elero_web_server.h` / `elero_web_server.cpp`
 

--- a/components/elero/__init__.py
+++ b/components/elero/__init__.py
@@ -58,6 +58,6 @@ async def to_code(config):
         if log_conf[CONF_LOGGING_ENABLE]:
             cg.add(var.set_persistent_log_enabled(True))
             cg.add(var.set_persistent_log_max_entries(log_conf[CONF_LOGGING_MAX_ENTRIES]))
-            # Ensure SPIFFS library is available for persistent logging
+            # Ensure LittleFS library is available for persistent logging
             if CORE.using_arduino:
-                cg.add_library("SPIFFS", None)
+                cg.add_library("LittleFS", None)

--- a/components/elero/elero_log.cpp
+++ b/components/elero/elero_log.cpp
@@ -4,16 +4,12 @@
 #include <cstring>
 #include <algorithm>
 
-#ifdef USE_ESP_IDF
-#if __has_include("esp_spiffs.h")
-#include "esp_spiffs.h"
-#elif __has_include(<esp_spiffs.h>)
-#include <esp_spiffs.h>
-#else
-#define ELERO_NO_ESP_SPIFFS
+#ifdef USE_ARDUINO
+#include <LittleFS.h>
 #endif
-#elif defined(USE_ARDUINO)
-#include "SPIFFS.h"
+
+#ifdef USE_ESP_IDF
+#include "esp_littlefs.h"
 #endif
 
 namespace esphome {
@@ -22,39 +18,35 @@ namespace elero {
 static const char *const TAG = "elero.log";
 
 bool EleroEventLog::begin(uint16_t max_entries) {
-#ifdef USE_ESP_IDF
-#ifdef ELERO_NO_ESP_SPIFFS
-  // esp_spiffs.h not available — try opening the file directly in case
-  // another component (e.g. ESPHome core) already mounted the filesystem.
-  ESP_LOGW(TAG, "esp_spiffs.h not found at compile time; "
-                "assuming filesystem is already mounted");
-#else
-  // Mount SPIFFS if not already mounted (ESP-IDF API)
-  esp_vfs_spiffs_conf_t spiffs_conf = {
-      .base_path = "/spiffs",
-      .partition_label = nullptr,
-      .max_files = 2,
-      .format_if_mount_failed = true,
-  };
+  // LittleFS is expected to be mounted already by EleroStorage::begin().
+  // If not, mount it here as a fallback.
+#ifdef USE_ARDUINO
+  if (!LittleFS.begin(false)) {  // false = don't format, try mount only
+    if (!LittleFS.begin(true)) { // true = format on first use
+      ESP_LOGE(TAG, "Failed to mount LittleFS");
+      return false;
+    }
+  }
+  ESP_LOGD(TAG, "LittleFS available for event log");
+#elif defined(USE_ESP_IDF)
+  // Try opening the log file directly — EleroStorage should have mounted
+  // LittleFS already. If it hasn't, mount it here.
+  esp_vfs_littlefs_conf_t conf = {};
+  conf.base_path = "/littlefs";
+  conf.partition_label = "spiffs";
+  conf.max_files = 5;
+  conf.format_if_mount_failed = true;
 
-  esp_err_t ret = esp_vfs_spiffs_register(&spiffs_conf);
+  esp_err_t ret = esp_vfs_littlefs_register(&conf);
   if (ret == ESP_ERR_INVALID_STATE) {
-    // Already mounted — that's fine
-    ESP_LOGD(TAG, "SPIFFS already mounted");
+    // Already mounted by EleroStorage — that's expected
+    ESP_LOGD(TAG, "LittleFS already mounted");
   } else if (ret != ESP_OK) {
-    ESP_LOGE(TAG, "Failed to mount SPIFFS: %s", esp_err_to_name(ret));
+    ESP_LOGE(TAG, "Failed to mount LittleFS: %s", esp_err_to_name(ret));
     return false;
   } else {
-    ESP_LOGD(TAG, "SPIFFS mounted successfully");
+    ESP_LOGD(TAG, "LittleFS mounted for event log");
   }
-#endif  // ELERO_NO_ESP_SPIFFS
-#elif defined(USE_ARDUINO) && defined(USE_ESP32)
-  // Mount SPIFFS (Arduino API) — true = format on first use
-  if (!SPIFFS.begin(true)) {
-    ESP_LOGE(TAG, "Failed to mount SPIFFS");
-    return false;
-  }
-  ESP_LOGD(TAG, "SPIFFS mounted successfully");
 #else
   ESP_LOGW(TAG, "Persistent logging only supported on ESP32");
   return false;

--- a/components/elero/elero_log.h
+++ b/components/elero/elero_log.h
@@ -76,7 +76,7 @@ class EleroEventLog {
   uint32_t next_sequence_{1};
   uint32_t append_count_{0};  // Count appends for header flush batching
   bool ready_{false};
-  static constexpr const char *LOG_PATH = "/spiffs/elero_events.bin";
+  static constexpr const char *LOG_PATH = "/littlefs/elero_events.bin";
   static constexpr uint32_t MAGIC = 0x454C4F47;  // "ELOG"
   static constexpr uint16_t FORMAT_VERSION = 1;
   static constexpr uint32_t HEADER_FLUSH_INTERVAL = 10;  // Flush header every N appends

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -29,7 +29,7 @@ elero:
 
 ### Persistentes Event-Logging
 
-Optionales SPIFFS-basiertes Event-Logging das RF-Pakete, Zustandsübergänge und gesendete Befehle aufzeichnet. Die Einträge überleben einen Neustart.
+Optionales LittleFS-basiertes Event-Logging das RF-Pakete, Zustandsübergänge und gesendete Befehle aufzeichnet. Die Einträge überleben einen Neustart.
 
 ```yaml
 elero:
@@ -52,7 +52,7 @@ elero:
 - **Befehl gesendet** — Adresse, Befehlsbyte
 - **System** — Boot, Fehler
 
-**Speicherverbrauch:** 1000 Einträge ≈ 64 KB auf SPIFFS. Die Einträge werden als Ringpuffer gespeichert — bei vollem Puffer werden die ältesten Einträge überschrieben.
+**Speicherverbrauch:** 1000 Einträge ≈ 64 KB auf LittleFS. Die Einträge werden als Ringpuffer gespeichert — bei vollem Puffer werden die ältesten Einträge überschrieben.
 
 ### Frequenz-Varianten
 

--- a/example.yaml
+++ b/example.yaml
@@ -12,7 +12,7 @@ elero:
   freq0: 0xc0
   freq1: 0x71
   freq2: 0x21
-  # Persistent event logging (survives reboot, stored on SPIFFS)
+  # Persistent event logging (survives reboot, stored on LittleFS)
   # logging:
   #   enable: true           # default: true when logging section is present
   #   max_entries: 1000      # default: 1000, range 100-5000 (~64KB at default)


### PR DESCRIPTION
## Summary
Migrates the persistent event logging system from SPIFFS to LittleFS across both Arduino and ESP-IDF platforms. This change improves filesystem reliability and compatibility while simplifying the mount logic.

## Key Changes

- **Filesystem migration**: Replaced all SPIFFS references with LittleFS in the event log implementation
  - Arduino: Changed from `SPIFFS.h` to `LittleFS.h`
  - ESP-IDF: Changed from `esp_spiffs.h` to `esp_littlefs.h`

- **Simplified mount logic**: 
  - Removed conditional compilation complexity (`ELERO_NO_ESP_SPIFFS` guard)
  - Arduino: Attempts non-destructive mount first, then formats on failure
  - ESP-IDF: Registers LittleFS with fallback mount if not already mounted by EleroStorage

- **Updated file paths**: Changed log file location from `/spiffs/elero_events.bin` to `/littlefs/elero_events.bin`

- **Updated dependencies**: Changed Arduino library dependency from `SPIFFS` to `LittleFS`

- **Documentation updates**: Updated all references in CLAUDE.md, CONFIGURATION.md, and example.yaml to reflect LittleFS usage

## Implementation Details

- The mount logic now assumes EleroStorage may have already mounted LittleFS, treating that as the expected case
- ESP-IDF configuration uses partition label `"spiffs"` for backward compatibility with existing flash layouts
- Arduino implementation uses a two-stage mount approach: first attempts to mount existing filesystem, then formats if needed
- All log messages updated to reference LittleFS instead of SPIFFS

https://claude.ai/code/session_01L8KkdPRFLpo89sw8dLXVty