### PR TITLE
Bump esp_littlefs dependency to v1.14.8

### DIFF
--- a/components/elero/__init__.py
+++ b/components/elero/__init__.py
@@ -63,5 +63,5 @@ async def to_code(config):
                 cg.add_library("LittleFS", None)
             if CORE.using_esp_idf:
                 cg.add_platformio_option(
-                    "lib_deps", ["joltwallet/esp_littlefs@^1.10.2"]
+                    "lib_deps", ["joltwallet/esp_littlefs@^1.14.8"]
                 )


### PR DESCRIPTION
## Summary
Updated the esp_littlefs PlatformIO library dependency version for ESP-IDF builds in the Elero component.

## Changes
- Updated `joltwallet/esp_littlefs` dependency from `^1.10.2` to `^1.14.8` in the PlatformIO configuration for ESP-IDF builds

## Details
This version bump ensures that ESP-IDF builds of the Elero component use a more recent version of the esp_littlefs library, which may include bug fixes, performance improvements, or compatibility enhancements.

https://claude.ai/code/session_01TWzRBuG9rrMJXXJYEvaeUz