### PR TITLE
Rename logging tags and fix unity build compilation

### DIFF
--- a/components/elero/elero.cpp
+++ b/components/elero/elero.cpp
@@ -1063,3 +1063,11 @@ void Elero::load_blind_states() {
 
 }  // namespace elero
 }  // namespace esphome
+
+// ─── Unity-build includes ─────────────────────────────────────────────────
+// ESPHome's build system only compiles .cpp files that have a corresponding
+// Python module.  elero_log.cpp and elero_storage.cpp are helper files with
+// no __init__.py of their own, so they are included here to ensure their
+// implementations are always compiled as part of this translation unit.
+#include "elero_log.cpp"      // NOLINT(build/include)
+#include "elero_storage.cpp"  // NOLINT(build/include)

--- a/components/elero/elero_log.cpp
+++ b/components/elero/elero_log.cpp
@@ -21,7 +21,7 @@
 namespace esphome {
 namespace elero {
 
-static const char *const TAG = "elero.log";
+static const char *const ELERO_LOG_TAG = "elero.log";
 
 bool EleroEventLog::begin(uint16_t max_entries) {
   // LittleFS is expected to be mounted already by EleroStorage::begin().
@@ -29,16 +29,16 @@ bool EleroEventLog::begin(uint16_t max_entries) {
 #ifdef USE_ARDUINO
   if (!LittleFS.begin(false)) {  // false = don't format, try mount only
     if (!LittleFS.begin(true)) { // true = format on first use
-      ESP_LOGE(TAG, "Failed to mount LittleFS");
+      ESP_LOGE(ELERO_LOG_TAG, "Failed to mount LittleFS");
       return false;
     }
   }
-  ESP_LOGD(TAG, "LittleFS available for event log");
+  ESP_LOGD(ELERO_LOG_TAG, "LittleFS available for event log");
 #elif defined(USE_ESP_IDF)
 #ifdef ELERO_NO_ESP_LITTLEFS
   // esp_littlefs.h not available — assume LittleFS is already mounted
   // by EleroStorage or externally.
-  ESP_LOGW(TAG, "esp_littlefs.h not found; assuming LittleFS is already mounted");
+  ESP_LOGW(ELERO_LOG_TAG, "esp_littlefs.h not found; assuming LittleFS is already mounted");
 #else
   // Try opening the log file directly — EleroStorage should have mounted
   // LittleFS already. If it hasn't, mount it here.
@@ -51,16 +51,16 @@ bool EleroEventLog::begin(uint16_t max_entries) {
   esp_err_t ret = esp_vfs_littlefs_register(&conf);
   if (ret == ESP_ERR_INVALID_STATE) {
     // Already mounted by EleroStorage — that's expected
-    ESP_LOGD(TAG, "LittleFS already mounted");
+    ESP_LOGD(ELERO_LOG_TAG, "LittleFS already mounted");
   } else if (ret != ESP_OK) {
-    ESP_LOGE(TAG, "Failed to mount LittleFS: %s", esp_err_to_name(ret));
+    ESP_LOGE(ELERO_LOG_TAG, "Failed to mount LittleFS: %s", esp_err_to_name(ret));
     return false;
   } else {
-    ESP_LOGD(TAG, "LittleFS mounted for event log");
+    ESP_LOGD(ELERO_LOG_TAG, "LittleFS mounted for event log");
   }
 #endif
 #else
-  ESP_LOGW(TAG, "Persistent logging only supported on ESP32");
+  ESP_LOGW(ELERO_LOG_TAG, "Persistent logging only supported on ESP32");
   return false;
 #endif
 
@@ -71,7 +71,7 @@ bool EleroEventLog::begin(uint16_t max_entries) {
     this->read_header_();
     if (this->header_.magic != MAGIC || this->header_.version != FORMAT_VERSION ||
         this->header_.max_entries != max_entries) {
-      ESP_LOGW(TAG, "Event log header invalid or max_entries changed, recreating");
+      ESP_LOGW(ELERO_LOG_TAG, "Event log header invalid or max_entries changed, recreating");
       fclose(this->file_);
       this->file_ = nullptr;
     } else {
@@ -81,7 +81,7 @@ bool EleroEventLog::begin(uint16_t max_entries) {
       if (this->header_.write_idx >= this->header_.max_entries) {
         this->header_.write_idx = 0;
       }
-      ESP_LOGI(TAG, "Event log opened: %u entries, %u total written",
+      ESP_LOGI(ELERO_LOG_TAG, "Event log opened: %u entries, %u total written",
                this->get_entry_count(), this->header_.total_written);
       this->ready_ = true;
       return true;
@@ -98,13 +98,13 @@ bool EleroEventLog::begin(uint16_t max_entries) {
 
   this->create_file_();
   if (this->file_ == nullptr) {
-    ESP_LOGE(TAG, "Failed to create event log file");
+    ESP_LOGE(ELERO_LOG_TAG, "Failed to create event log file");
     return false;
   }
 
   this->next_sequence_ = 1;
   this->ready_ = true;
-  ESP_LOGI(TAG, "Event log created: max %u entries (%" PRIu32 " bytes)",
+  ESP_LOGI(ELERO_LOG_TAG, "Event log created: max %u entries (%" PRIu32 " bytes)",
            max_entries, (uint32_t)(64 + max_entries * 64));
   return true;
 }
@@ -143,7 +143,7 @@ void EleroEventLog::write_header_() {
     return;
   fseek(this->file_, 0, SEEK_SET);
   if (fwrite(&this->header_, sizeof(PersistentLogHeader), 1, this->file_) != 1) {
-    ESP_LOGE(TAG, "Failed to write event log header");
+    ESP_LOGE(ELERO_LOG_TAG, "Failed to write event log header");
     this->ready_ = false;
     return;
   }
@@ -155,7 +155,7 @@ void EleroEventLog::read_header_() {
     return;
   fseek(this->file_, 0, SEEK_SET);
   if (fread(&this->header_, sizeof(PersistentLogHeader), 1, this->file_) != 1) {
-    ESP_LOGE(TAG, "Failed to read event log header");
+    ESP_LOGE(ELERO_LOG_TAG, "Failed to read event log header");
     memset(&this->header_, 0, sizeof(this->header_));
   }
 }
@@ -166,7 +166,7 @@ void EleroEventLog::write_entry_(uint16_t idx, const PersistentLogEntry &entry) 
   long offset = sizeof(PersistentLogHeader) + (long)idx * sizeof(PersistentLogEntry);
   fseek(this->file_, offset, SEEK_SET);
   if (fwrite(&entry, sizeof(PersistentLogEntry), 1, this->file_) != 1) {
-    ESP_LOGW(TAG, "Failed to write event log entry at index %u", idx);
+    ESP_LOGW(ELERO_LOG_TAG, "Failed to write event log entry at index %u", idx);
   }
   fflush(this->file_);
 }
@@ -178,7 +178,7 @@ PersistentLogEntry EleroEventLog::read_entry_(uint16_t idx) const {
   long offset = sizeof(PersistentLogHeader) + (long)idx * sizeof(PersistentLogEntry);
   fseek(this->file_, offset, SEEK_SET);
   if (fread(&entry, sizeof(PersistentLogEntry), 1, this->file_) != 1) {
-    ESP_LOGW(TAG, "Failed to read event log entry at index %u", idx);
+    ESP_LOGW(ELERO_LOG_TAG, "Failed to read event log entry at index %u", idx);
     memset(&entry, 0, sizeof(entry));
   }
   return entry;
@@ -269,7 +269,7 @@ void EleroEventLog::clear() {
     this->write_entry_(i, empty);
   }
 
-  ESP_LOGI(TAG, "Event log cleared");
+  ESP_LOGI(ELERO_LOG_TAG, "Event log cleared");
 }
 
 // ─── Convenience logging methods ──────────────────────────────────────────

--- a/components/elero/elero_storage.cpp
+++ b/components/elero/elero_storage.cpp
@@ -19,7 +19,7 @@
 namespace esphome {
 namespace elero {
 
-static const char *const TAG = "elero.storage";
+static const char *const ELERO_STORAGE_TAG = "elero.storage";
 
 static const char *const BLINDS_PATH  = "/littlefs/elero_rt.bin";
 static const char *const PACKETS_PATH = "/littlefs/elero_pkt.bin";
@@ -31,18 +31,18 @@ bool EleroStorage::begin() {
 
 #ifdef USE_ARDUINO
   if (!LittleFS.begin(true)) {  // true = format partition on first use
-    ESP_LOGE(TAG, "Failed to mount LittleFS");
+    ESP_LOGE(ELERO_STORAGE_TAG, "Failed to mount LittleFS");
     return false;
   }
   mounted_ = true;
-  ESP_LOGI(TAG, "LittleFS mounted");
+  ESP_LOGI(ELERO_STORAGE_TAG, "LittleFS mounted");
 #endif
 
 #ifdef USE_ESP_IDF
 #ifdef ELERO_NO_ESP_LITTLEFS
   // esp_littlefs.h not available — assume the filesystem will be mounted
   // externally or try to use POSIX file I/O directly.
-  ESP_LOGW(TAG, "esp_littlefs.h not found; assuming LittleFS is already mounted");
+  ESP_LOGW(ELERO_STORAGE_TAG, "esp_littlefs.h not found; assuming LittleFS is already mounted");
   mounted_ = true;
 #else
   esp_vfs_littlefs_conf_t conf = {};
@@ -53,14 +53,14 @@ bool EleroStorage::begin() {
 
   esp_err_t ret = esp_vfs_littlefs_register(&conf);
   if (ret == ESP_ERR_INVALID_STATE) {
-    ESP_LOGD(TAG, "LittleFS already mounted");
+    ESP_LOGD(ELERO_STORAGE_TAG, "LittleFS already mounted");
     mounted_ = true;
   } else if (ret != ESP_OK) {
-    ESP_LOGE(TAG, "Failed to mount LittleFS: %s", esp_err_to_name(ret));
+    ESP_LOGE(ELERO_STORAGE_TAG, "Failed to mount LittleFS: %s", esp_err_to_name(ret));
     return false;
   } else {
     mounted_ = true;
-    ESP_LOGI(TAG, "LittleFS mounted");
+    ESP_LOGI(ELERO_STORAGE_TAG, "LittleFS mounted");
   }
 #endif
 #endif
@@ -75,7 +75,7 @@ bool EleroStorage::save_runtime_blinds(const std::map<uint32_t, RuntimeBlind> &b
 
   FILE *f = fopen(BLINDS_PATH, "wb");
   if (!f) {
-    ESP_LOGE(TAG, "Failed to open %s for writing", BLINDS_PATH);
+    ESP_LOGE(ELERO_STORAGE_TAG, "Failed to open %s for writing", BLINDS_PATH);
     return false;
   }
 
@@ -109,7 +109,7 @@ bool EleroStorage::save_runtime_blinds(const std::map<uint32_t, RuntimeBlind> &b
   }
 
   fclose(f);
-  ESP_LOGD(TAG, "Saved %d runtime blind(s) to flash", count);
+  ESP_LOGD(ELERO_STORAGE_TAG, "Saved %d runtime blind(s) to flash", count);
   return true;
 }
 
@@ -118,7 +118,7 @@ bool EleroStorage::load_runtime_blinds(std::map<uint32_t, RuntimeBlind> &blinds)
 
   FILE *f = fopen(BLINDS_PATH, "rb");
   if (!f) {
-    ESP_LOGD(TAG, "No runtime blinds file found (first boot)");
+    ESP_LOGD(ELERO_STORAGE_TAG, "No runtime blinds file found (first boot)");
     return false;
   }
 
@@ -127,17 +127,17 @@ bool EleroStorage::load_runtime_blinds(std::map<uint32_t, RuntimeBlind> &blinds)
   uint16_t count = 0;
 
   if (fread(&magic, sizeof(magic), 1, f) != 1 || magic != STORAGE_MAGIC_BLINDS) {
-    ESP_LOGW(TAG, "Invalid runtime blinds file (bad magic)");
+    ESP_LOGW(ELERO_STORAGE_TAG, "Invalid runtime blinds file (bad magic)");
     fclose(f);
     return false;
   }
   if (fread(&version, sizeof(version), 1, f) != 1 || version != STORAGE_VERSION_1) {
-    ESP_LOGW(TAG, "Unsupported runtime blinds file version %d", version);
+    ESP_LOGW(ELERO_STORAGE_TAG, "Unsupported runtime blinds file version %d", version);
     fclose(f);
     return false;
   }
   if (fread(&count, sizeof(count), 1, f) != 1) {
-    ESP_LOGW(TAG, "Failed to read runtime blinds count");
+    ESP_LOGW(ELERO_STORAGE_TAG, "Failed to read runtime blinds count");
     fclose(f);
     return false;
   }
@@ -145,7 +145,7 @@ bool EleroStorage::load_runtime_blinds(std::map<uint32_t, RuntimeBlind> &blinds)
   for (uint16_t i = 0; i < count; i++) {
     RuntimeBlindRecord rec{};
     if (fread(&rec, sizeof(rec), 1, f) != 1) {
-      ESP_LOGW(TAG, "Truncated runtime blinds file at record %d", i);
+      ESP_LOGW(ELERO_STORAGE_TAG, "Truncated runtime blinds file at record %d", i);
       break;
     }
 
@@ -168,7 +168,7 @@ bool EleroStorage::load_runtime_blinds(std::map<uint32_t, RuntimeBlind> &blinds)
   }
 
   fclose(f);
-  ESP_LOGI(TAG, "Loaded %d runtime blind(s) from flash", count);
+  ESP_LOGI(ELERO_STORAGE_TAG, "Loaded %d runtime blind(s) from flash", count);
   return true;
 }
 
@@ -179,7 +179,7 @@ bool EleroStorage::save_packets(const std::vector<RawPacket> &packets, uint8_t w
 
   FILE *f = fopen(PACKETS_PATH, "wb");
   if (!f) {
-    ESP_LOGE(TAG, "Failed to open %s for writing", PACKETS_PATH);
+    ESP_LOGE(ELERO_STORAGE_TAG, "Failed to open %s for writing", PACKETS_PATH);
     return false;
   }
 
@@ -202,7 +202,7 @@ bool EleroStorage::save_packets(const std::vector<RawPacket> &packets, uint8_t w
   }
 
   fclose(f);
-  ESP_LOGD(TAG, "Saved %d RF packet(s) to flash", count);
+  ESP_LOGD(ELERO_STORAGE_TAG, "Saved %d RF packet(s) to flash", count);
   return true;
 }
 
@@ -211,7 +211,7 @@ bool EleroStorage::load_packets(std::vector<RawPacket> &packets, uint8_t &write_
 
   FILE *f = fopen(PACKETS_PATH, "rb");
   if (!f) {
-    ESP_LOGD(TAG, "No packet log file found");
+    ESP_LOGD(ELERO_STORAGE_TAG, "No packet log file found");
     return false;
   }
 
@@ -221,18 +221,18 @@ bool EleroStorage::load_packets(std::vector<RawPacket> &packets, uint8_t &write_
   uint8_t widx = 0;
 
   if (fread(&magic, sizeof(magic), 1, f) != 1 || magic != STORAGE_MAGIC_PACKETS) {
-    ESP_LOGW(TAG, "Invalid packet log file (bad magic)");
+    ESP_LOGW(ELERO_STORAGE_TAG, "Invalid packet log file (bad magic)");
     fclose(f);
     return false;
   }
   if (fread(&version, sizeof(version), 1, f) != 1 || version != STORAGE_VERSION_1) {
-    ESP_LOGW(TAG, "Unsupported packet log version %d", version);
+    ESP_LOGW(ELERO_STORAGE_TAG, "Unsupported packet log version %d", version);
     fclose(f);
     return false;
   }
   if (fread(&count, sizeof(count), 1, f) != 1 ||
       fread(&widx, sizeof(widx), 1, f) != 1) {
-    ESP_LOGW(TAG, "Failed to read packet log header");
+    ESP_LOGW(ELERO_STORAGE_TAG, "Failed to read packet log header");
     fclose(f);
     return false;
   }
@@ -252,7 +252,7 @@ bool EleroStorage::load_packets(std::vector<RawPacket> &packets, uint8_t &write_
 
   write_idx = widx;
   fclose(f);
-  ESP_LOGI(TAG, "Loaded %zu RF packet(s) from flash", packets.size());
+  ESP_LOGI(ELERO_STORAGE_TAG, "Loaded %zu RF packet(s) from flash", packets.size());
   return true;
 }
 
@@ -263,7 +263,7 @@ bool EleroStorage::save_blind_states(const std::vector<PersistedBlindState> &sta
 
   FILE *f = fopen(STATES_PATH, "wb");
   if (!f) {
-    ESP_LOGE(TAG, "Failed to open %s for writing", STATES_PATH);
+    ESP_LOGE(ELERO_STORAGE_TAG, "Failed to open %s for writing", STATES_PATH);
     return false;
   }
 
@@ -280,7 +280,7 @@ bool EleroStorage::save_blind_states(const std::vector<PersistedBlindState> &sta
   }
 
   fclose(f);
-  ESP_LOGD(TAG, "Saved %d blind state(s) to flash", count);
+  ESP_LOGD(ELERO_STORAGE_TAG, "Saved %d blind state(s) to flash", count);
   return true;
 }
 
@@ -289,7 +289,7 @@ bool EleroStorage::load_blind_states(std::vector<PersistedBlindState> &states) {
 
   FILE *f = fopen(STATES_PATH, "rb");
   if (!f) {
-    ESP_LOGD(TAG, "No blind state file found");
+    ESP_LOGD(ELERO_STORAGE_TAG, "No blind state file found");
     return false;
   }
 
@@ -298,17 +298,17 @@ bool EleroStorage::load_blind_states(std::vector<PersistedBlindState> &states) {
   uint16_t count = 0;
 
   if (fread(&magic, sizeof(magic), 1, f) != 1 || magic != STORAGE_MAGIC_STATES) {
-    ESP_LOGW(TAG, "Invalid blind state file (bad magic)");
+    ESP_LOGW(ELERO_STORAGE_TAG, "Invalid blind state file (bad magic)");
     fclose(f);
     return false;
   }
   if (fread(&version, sizeof(version), 1, f) != 1 || version != STORAGE_VERSION_1) {
-    ESP_LOGW(TAG, "Unsupported blind state version %d", version);
+    ESP_LOGW(ELERO_STORAGE_TAG, "Unsupported blind state version %d", version);
     fclose(f);
     return false;
   }
   if (fread(&count, sizeof(count), 1, f) != 1) {
-    ESP_LOGW(TAG, "Failed to read blind state count");
+    ESP_LOGW(ELERO_STORAGE_TAG, "Failed to read blind state count");
     fclose(f);
     return false;
   }
@@ -323,7 +323,7 @@ bool EleroStorage::load_blind_states(std::vector<PersistedBlindState> &states) {
   }
 
   fclose(f);
-  ESP_LOGI(TAG, "Loaded %zu blind state(s) from flash", states.size());
+  ESP_LOGI(ELERO_STORAGE_TAG, "Loaded %zu blind state(s) from flash", states.size());
   return true;
 }
 


### PR DESCRIPTION
## Summary
This PR addresses two issues in the Elero component:
1. Renames generic logging tags to be more specific and avoid potential conflicts
2. Fixes compilation in unity builds by explicitly including helper source files

## Key Changes

- **Logging tag renaming**: Renamed generic `TAG` constants to more specific names:
  - `elero_storage.cpp`: `TAG` → `ELERO_STORAGE_TAG`
  - `elero_log.cpp`: `TAG` → `ELERO_LOG_TAG`
  - Updated all logging calls (ESP_LOGE, ESP_LOGI, ESP_LOGD, ESP_LOGW) to use the new tag names

- **Unity build fix**: Added explicit includes at the end of `elero.cpp`:
  - Included `elero_log.cpp` and `elero_storage.cpp` as source files
  - Added explanatory comment about ESPHome's build system requiring this approach for helper files without their own Python modules
  - Added NOLINT directives to suppress build system warnings about unconventional includes

## Implementation Details

The logging tag changes improve code clarity and reduce the risk of tag collisions when multiple components use generic names. The unity build fix ensures that helper implementation files are compiled even when they don't have corresponding Python module definitions, which is required by ESPHome's build system.

https://claude.ai/code/session_01SRTc3YVNiWSdUNE2VZtjrf