### PR TITLE
Use git URL for esp_littlefs dependency instead of version pin

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -575,7 +575,7 @@ Default frequency registers (`freq2=0x21, freq1=0x71, freq0=0x7a`) correspond to
 
 **LittleFS / partition table** — handled automatically by `__init__.py`:
 - **Arduino framework**: adds the `LittleFS` library and sets `board_build.partitions = default.csv` (bundled with arduino-esp32; provides a `spiffs` partition on standard 4 MB boards). For 8 MB / 16 MB flash boards override via `platformio_options: board_build.partitions: default_8MB.csv`.
-- **ESP-IDF framework**: adds `joltwallet/esp_littlefs@^1.10.2` as a lib dependency and generates `elero_partitions.csv` (4 MB OTA + SPIFFS layout) next to the user's YAML config, then sets `board_build.partitions` to its absolute path.
+- **ESP-IDF framework**: adds `https://github.com/joltwallet/esp_littlefs.git` as a lib dependency and generates `elero_partitions.csv` (4 MB OTA + SPIFFS layout) next to the user's YAML config, then sets `board_build.partitions` to its absolute path.
 - Users can always override the partition table with `platformio_options: board_build.partitions:` in their ESPHome YAML — user options are processed last and take precedence.
 
 SPI bus must be declared separately:

--- a/components/elero/__init__.py
+++ b/components/elero/__init__.py
@@ -96,7 +96,7 @@ async def to_code(config):
 
     if CORE.using_esp_idf:
         cg.add_platformio_option(
-            "lib_deps", ["joltwallet/esp_littlefs@^1.10.2"]
+            "lib_deps", ["https://github.com/joltwallet/esp_littlefs.git"]
         )
         # Generate a partition CSV with a SPIFFS partition next to the YAML and
         # point PlatformIO at it via an absolute path.
@@ -113,5 +113,5 @@ async def to_code(config):
                 cg.add_library("LittleFS", None)
             if CORE.using_esp_idf:
                 cg.add_platformio_option(
-                    "lib_deps", ["joltwallet/esp_littlefs@^1.14.8"]
+                    "lib_deps", ["https://github.com/joltwallet/esp_littlefs.git"]
                 )


### PR DESCRIPTION
## Summary
Updated the esp_littlefs library dependency configuration to use a direct git repository URL instead of pinned version numbers. This change applies to both ESP-IDF framework configurations in the elero component.

## Changes
- Replaced `joltwallet/esp_littlefs@^1.10.2` with `https://github.com/joltwallet/esp_littlefs.git` for the initial ESP-IDF configuration
- Replaced `joltwallet/esp_littlefs@^1.14.8` with `https://github.com/joltwallet/esp_littlefs.git` for the secondary ESP-IDF configuration
- Updated documentation in CLAUDE.md to reflect the new dependency specification

## Details
This change allows the build system to always use the latest version from the main branch of the esp_littlefs repository rather than being constrained to specific semantic versions. This approach provides more flexibility for receiving updates and bug fixes without requiring manual version bumps in the configuration.

https://claude.ai/code/session_01S5JRQ93cBzjs4xppFar7Xe