### PR TITLE
fix: upgrade log levels so operational logs are visible at default DEBUG level

### DIFF
--- a/components/elero/cover/EleroCover.cpp
+++ b/components/elero/cover/EleroCover.cpp
@@ -25,7 +25,7 @@ void EleroCover::dump_config() {
 
 void EleroCover::setup() {
   if (this->parent_ == nullptr) {
-    ESP_LOGE(TAG, "Elero parent not configured");
+    ESP_LOGE(TAG, "Elero parent not configured for cover '%s'", this->get_name().c_str());
     this->mark_failed();
     return;
   }
@@ -37,6 +37,11 @@ void EleroCover::setup() {
     if((this->open_duration_ > 0) && (this->close_duration_ > 0))
       this->position = 0.5f;
   }
+  // Publish initial state so Home Assistant has correct state on boot
+  this->publish_state(false);
+  ESP_LOGI(TAG, "Cover '%s' ready: blind=0x%06x, remote=0x%06x, ch=%d, poll=%dms",
+           this->get_name().c_str(), this->command_.blind_addr,
+           this->command_.remote_addr, this->command_.channel, this->poll_intvl_);
 }
 
 void EleroCover::loop() {
@@ -108,15 +113,17 @@ void EleroCover::handle_commands(uint32_t now) {
         this->send_packets_++;
         this->send_retries_ = 0;
         if(this->send_packets_ >= ELERO_SEND_PACKETS) {
+          ESP_LOGD(TAG, "Blind 0x%06x: command 0x%02x sent successfully",
+                   this->command_.blind_addr, this->commands_to_send_.front());
           this->commands_to_send_.pop();
           this->send_packets_ = 0;
           this->increase_counter();
         }
       } else {
-        ESP_LOGD(TAG, "Retry #%d for blind 0x%06x", this->send_retries_, this->command_.blind_addr);
+        ESP_LOGD(TAG, "TX busy, retry #%d for blind 0x%06x", this->send_retries_, this->command_.blind_addr);
         this->send_retries_++;
         if(this->send_retries_ > ELERO_SEND_RETRIES) {
-          ESP_LOGE(TAG, "Hit maximum number of retries, giving up.");
+          ESP_LOGE(TAG, "Blind 0x%06x: hit maximum retries, giving up", this->command_.blind_addr);
           this->send_retries_ = 0;
           this->commands_to_send_.pop();
         }
@@ -144,7 +151,7 @@ cover::CoverTraits EleroCover::get_traits() {
 void EleroCover::set_rx_state(uint8_t state) {
   uint8_t old_state = this->last_state_raw_;  // Capture before overwrite for logging
   this->last_state_raw_ = state;
-  ESP_LOGV(TAG, "Got state: 0x%02x (%s) for blind 0x%06x", state, elero_state_to_string(state), this->command_.blind_addr);
+  ESP_LOGD(TAG, "Blind 0x%06x state: 0x%02x (%s)", this->command_.blind_addr, state, elero_state_to_string(state));
   float pos = this->position;
   float current_tilt = this->tilt;
   CoverOperation op = this->current_operation;
@@ -211,6 +218,12 @@ void EleroCover::set_rx_state(uint8_t state) {
   }
 
   if((pos != this->position) || (op != this->current_operation) || (current_tilt != this->tilt)) {
+    ESP_LOGI(TAG, "Blind 0x%06x state change: %s -> %s (pos=%.0f%%, op=%s)",
+             this->command_.blind_addr,
+             elero_state_to_string(old_state), elero_state_to_string(state),
+             pos * 100.0f,
+             op == cover::COVER_OPERATION_IDLE ? "idle" :
+             op == cover::COVER_OPERATION_OPENING ? "opening" : "closing");
     // Log state transition to persistent log
     if (this->parent_->is_persistent_log_enabled()) {
       auto *log = this->parent_->get_event_log();
@@ -275,7 +288,7 @@ void EleroCover::control(const cover::CoverCall &call) {
 void EleroCover::start_movement(CoverOperation dir) {
   switch(dir) {
     case COVER_OPERATION_OPENING:
-      ESP_LOGV(TAG, "Sending OPEN command");
+      ESP_LOGD(TAG, "Blind 0x%06x: sending OPEN (cmd=0x%02x)", this->command_.blind_addr, this->command_up_);
       if (this->commands_to_send_.size() < ELERO_MAX_COMMAND_QUEUE) {
         this->commands_to_send_.push(this->command_up_);
         // Reset tilt state on movement
@@ -284,7 +297,7 @@ void EleroCover::start_movement(CoverOperation dir) {
       }
     break;
     case COVER_OPERATION_CLOSING:
-      ESP_LOGV(TAG, "Sending CLOSE command");
+      ESP_LOGD(TAG, "Blind 0x%06x: sending CLOSE (cmd=0x%02x)", this->command_.blind_addr, this->command_down_);
       if (this->commands_to_send_.size() < ELERO_MAX_COMMAND_QUEUE) {
         this->commands_to_send_.push(this->command_down_);
         // Reset tilt state on movement
@@ -293,6 +306,7 @@ void EleroCover::start_movement(CoverOperation dir) {
       }
     break;
     case COVER_OPERATION_IDLE:
+      ESP_LOGD(TAG, "Blind 0x%06x: sending STOP (cmd=0x%02x)", this->command_.blind_addr, this->command_stop_);
       // Clear any pending movement commands so STOP is sent immediately
       while (!this->commands_to_send_.empty())
         this->commands_to_send_.pop();

--- a/components/elero/elero.cpp
+++ b/components/elero/elero.cpp
@@ -79,7 +79,7 @@ void Elero::loop() {
   }
 
   if(this->received_) {
-    ESP_LOGVV(TAG, "loop says \"received\"");
+    ESP_LOGD(TAG, "RF packet received, reading FIFO");
     uint8_t len = this->read_status(CC1101_RXBYTES);
     if(len & 0x80) { // overflow - FIFO data unreliable
       ESP_LOGV(TAG, "Rx overflow, flushing FIFOs");
@@ -139,19 +139,41 @@ void Elero::setup() {
   this->reset();
   this->init();
 
+  // Verify CC1101 is responding over SPI by reading back a known register
+  uint8_t freq2_readback = this->read_reg(CC1101_FREQ2);
+  if (freq2_readback == this->freq2_) {
+    ESP_LOGI(TAG, "CC1101 SPI communication verified (FREQ2=0x%02x)", freq2_readback);
+  } else {
+    ESP_LOGE(TAG, "CC1101 SPI verification FAILED: wrote FREQ2=0x%02x, read back 0x%02x — check SPI wiring and CS pin!",
+             this->freq2_, freq2_readback);
+  }
+  ESP_LOGI(TAG, "CC1101 frequency: freq2=0x%02x, freq1=0x%02x, freq0=0x%02x",
+           this->freq2_, this->freq1_, this->freq0_);
+
   // Mount LittleFS and restore persisted data
   if (this->storage_.begin()) {
+    ESP_LOGI(TAG, "LittleFS mounted, restoring persisted data");
     this->storage_.load_runtime_blinds(this->runtime_blinds_);
     this->load_packet_log();
     this->load_blind_states();
+    if (!this->runtime_blinds_.empty()) {
+      ESP_LOGI(TAG, "Restored %d runtime-adopted blind(s)", this->runtime_blinds_.size());
+    }
+  } else {
+    ESP_LOGW(TAG, "LittleFS mount failed — runtime blind persistence disabled");
   }
 
   // Initialize persistent event log if enabled
   if (this->persistent_log_enabled_) {
     if (this->event_log_.begin(this->persistent_log_max_entries_)) {
+      ESP_LOGI(TAG, "Persistent event log enabled (max %d entries)", this->persistent_log_max_entries_);
       this->event_log_.log_system("Elero hub started");
+    } else {
+      ESP_LOGW(TAG, "Persistent event log failed to initialize");
     }
   }
+
+  ESP_LOGI(TAG, "Elero setup complete");
 }
 
 void Elero::reinit_frequency(uint8_t freq2, uint8_t freq1, uint8_t freq0) {
@@ -165,7 +187,7 @@ void Elero::reinit_frequency(uint8_t freq2, uint8_t freq1, uint8_t freq0) {
 }
 
 void Elero::flush_and_rx() {
-  ESP_LOGVV(TAG, "flush_and_rx");
+  ESP_LOGV(TAG, "Flushing FIFOs and entering RX mode");
   this->write_cmd(CC1101_SIDLE);
   this->wait_idle();
   this->write_cmd(CC1101_SFRX);
@@ -288,10 +310,10 @@ bool Elero::wait_idle() {
 
 bool Elero::transmit() {
   if (this->tx_phase_ != TxPhase::IDLE) {
-    ESP_LOGVV(TAG, "transmit: TX busy");
+    ESP_LOGD(TAG, "TX busy, deferring transmit");
     return false;
   }
-  ESP_LOGVV(TAG, "transmit: starting for %d data bytes", this->msg_tx_[0]);
+  ESP_LOGD(TAG, "Starting TX (%d data bytes)", this->msg_tx_[0]);
   // Go to IDLE first so the subsequent STX is not subject to CCA.
   // (STX from RX with MCSM1 CCA_MODE=3 requires a clear channel, which
   // fails when Elero motors are actively transmitting status replies.)
@@ -346,7 +368,7 @@ void Elero::advance_tx_() {
         if (bytes != 0)
           ESP_LOGE(TAG, "Error transferring, %d bytes left in buffer", bytes);
         else
-          ESP_LOGV(TAG, "Transmission successful");
+          ESP_LOGD(TAG, "Transmission successful");
         this->flush_and_rx();  // return chip to clean RX state and clear received_
         this->tx_phase_ = TxPhase::IDLE;
       } else if (millis() > this->tx_deadline_ms_) {
@@ -879,7 +901,8 @@ void Elero::track_discovered_blind(uint32_t src, uint32_t remote, uint8_t channe
 }
 
 bool Elero::send_command(t_elero_command *cmd) {
-  ESP_LOGVV(TAG, "send_command called");
+  ESP_LOGD(TAG, "Sending command 0x%02x to blind 0x%06x (counter=%d)",
+           cmd->payload[4], cmd->blind_addr, cmd->counter);
   // Log command sent to persistent log
   if (this->persistent_log_enabled_ && this->event_log_.is_ready()) {
     this->event_log_.log_command_sent(cmd->blind_addr, cmd->payload[4]);

--- a/components/elero/light/EleroLight.cpp
+++ b/components/elero/light/EleroLight.cpp
@@ -182,8 +182,9 @@ void EleroLight::recompute_brightness() {
 }
 
 void EleroLight::set_rx_state(uint8_t state) {
-  ESP_LOGV(TAG, "Got state: 0x%02x for light 0x%06x",
-           state, this->command_.blind_addr);
+  ESP_LOGD(TAG, "Light 0x%06x state: 0x%02x (%s)",
+           this->command_.blind_addr, state,
+           elero_state_to_string(state, true));
 
   if (state == ELERO_STATE_ON) {
     if (!this->is_on_) {

--- a/components/elero_web/elero_web_server.cpp
+++ b/components/elero_web/elero_web_server.cpp
@@ -92,13 +92,14 @@ bool EleroWebServer::parse_addr_url(const std::string &url, const char *prefix,
 // ─── Setup / config ───────────────────────────────────────────────────────────
 
 void EleroWebServer::setup() {
+  ESP_LOGI(TAG, "Setting up Elero Web Server...");
   if (this->base_ == nullptr) {
-    ESP_LOGE(TAG, "web_server_base not set, cannot start Elero Web UI");
+    ESP_LOGE(TAG, "web_server_base not set — add 'web_server_base:' to your YAML config");
     this->mark_failed();
     return;
   }
   if (this->parent_ == nullptr) {
-    ESP_LOGE(TAG, "Elero parent not set, cannot start Elero Web UI");
+    ESP_LOGE(TAG, "Elero parent not set — add 'elero:' hub to your YAML config");
     this->mark_failed();
     return;
   }
@@ -107,13 +108,13 @@ void EleroWebServer::setup() {
 
   auto *server = this->base_->get_server();
   if (server == nullptr) {
-    ESP_LOGE(TAG, "Failed to get web server instance");
+    ESP_LOGE(TAG, "Failed to get web server instance — web_server_base may not be configured correctly");
     this->mark_failed();
     return;
   }
 
   server->addHandler(this);
-  ESP_LOGI(TAG, "Elero Web UI available at /elero");
+  ESP_LOGI(TAG, "Elero Web UI available at http://<device-ip>/elero (port %d)", this->base_->get_port());
 }
 
 void EleroWebServer::dump_config() {


### PR DESCRIPTION
All critical operational logs were at VERBOSE/VERY_VERBOSE level, making
them invisible at ESPHome's default DEBUG log level. This left users with
no visibility into RF activity, command sends, state updates, or errors.

Changes:
- Upgrade set_rx_state, send_command, transmit, start_movement logs from
  VERBOSE/VERY_VERBOSE to DEBUG so they appear in normal ESPHome output
- Add CC1101 SPI verification in setup() to detect hardware/wiring issues
- Add initial state publish in EleroCover::setup() for correct HA state on boot
- Add INFO-level cover ready log with blind address, remote, channel, poll
- Add INFO-level state change log (old -> new) for cover transitions
- Improve web server setup with actionable error messages
- Add LittleFS mount status and persistent log init logging
- Include blind address in all cover/light log messages for multi-blind setups

https://claude.ai/code/session_01WyB1Es2KfLNSYv3UGynTp6