### PR TITLE
Improve blocking state handling: error recovery, non-blocking flush, movement timeout

### DIFF
--- a/components/elero/cover/EleroCover.cpp
+++ b/components/elero/cover/EleroCover.cpp
@@ -48,8 +48,16 @@ void EleroCover::loop() {
   uint32_t intvl = this->poll_intvl_;
   uint32_t now = millis();
   if(this->current_operation != COVER_OPERATION_IDLE) {
-    if((now - this->movement_start_) < ELERO_TIMEOUT_MOVEMENT)  // Poll frequently while moving (up to 2 min timeout)
-      intvl = ELERO_POLL_INTERVAL_MOVING;
+    if(this->movement_start_ > 0 && (now - this->movement_start_) > ELERO_TIMEOUT_MOVEMENT) {
+      // Force idle if movement timed out with no RF feedback
+      ESP_LOGW(TAG, "Blind 0x%06x: movement timed out after %us with no RF feedback, forcing idle",
+               this->command_.blind_addr, ELERO_TIMEOUT_MOVEMENT / 1000);
+      this->current_operation = COVER_OPERATION_IDLE;
+      this->movement_start_ = 0;
+      this->publish_state();
+    } else {
+      intvl = ELERO_POLL_INTERVAL_MOVING;  // Poll frequently while moving
+    }
   }
 
   if((now > this->poll_offset_) && (now - this->poll_offset_ - this->last_poll_) > intvl) {
@@ -201,16 +209,19 @@ void EleroCover::set_rx_state(uint8_t state) {
     current_tilt = 0.0;
     break;
   case ELERO_STATE_BLOCKING:
-    ESP_LOGW(TAG, "Blind 0x%06x reports BLOCKING", this->command_.blind_addr);
-    op = COVER_OPERATION_IDLE;
-    break;
   case ELERO_STATE_OVERHEATED:
-    ESP_LOGW(TAG, "Blind 0x%06x reports OVERHEATED", this->command_.blind_addr);
-    op = COVER_OPERATION_IDLE;
-    break;
   case ELERO_STATE_TIMEOUT:
-    ESP_LOGW(TAG, "Blind 0x%06x reports TIMEOUT", this->command_.blind_addr);
+    ESP_LOGW(TAG, "Blind 0x%06x reports %s", this->command_.blind_addr,
+             elero_state_to_string(state));
     op = COVER_OPERATION_IDLE;
+    // Flush pending commands — motor is in error, don't send more
+    while (!this->commands_to_send_.empty()) this->commands_to_send_.pop();
+    this->send_packets_ = 0;
+    this->send_retries_ = 0;
+    // Cancel movement tracking
+    this->movement_start_ = 0;
+    // Schedule recovery poll (10s later) to check if blind has recovered
+    this->post_movement_poll_at_ = millis() + 10000;
     break;
   default:
     op = COVER_OPERATION_IDLE;

--- a/components/elero/elero.cpp
+++ b/components/elero/elero.cpp
@@ -78,12 +78,12 @@ void Elero::loop() {
     this->last_state_save_ms_ = millis();
   }
 
-  if(this->received_) {
+  if(this->received_ && this->tx_phase_ == TxPhase::IDLE) {
     ESP_LOGD(TAG, "RF packet received, reading FIFO");
     uint8_t len = this->read_status(CC1101_RXBYTES);
     if(len & 0x80) { // overflow - FIFO data unreliable
       ESP_LOGV(TAG, "Rx overflow, flushing FIFOs");
-      this->flush_and_rx();
+      this->start_flush_rx_();
       return;
     }
     if(len & 0x7F) { // bytes available
@@ -313,6 +313,12 @@ bool Elero::transmit() {
   return true;
 }
 
+void Elero::start_flush_rx_() {
+  this->write_cmd(CC1101_SIDLE);
+  this->tx_deadline_ms_ = millis() + 100;
+  this->tx_phase_ = TxPhase::FLUSH_RX;
+}
+
 void Elero::advance_tx_() {
   switch (this->tx_phase_) {
     case TxPhase::IDLE:
@@ -335,8 +341,7 @@ void Elero::advance_tx_() {
       } else if (millis() > this->tx_deadline_ms_) {
         ESP_LOGE(TAG, "Timed out waiting for Idle: 0x%02x",
                  this->read_status(CC1101_MARCSTATE));
-        this->flush_and_rx();
-        this->tx_phase_ = TxPhase::IDLE;
+        this->start_flush_rx_();
       }
       break;
 
@@ -354,13 +359,11 @@ void Elero::advance_tx_() {
           ESP_LOGE(TAG, "Error transferring, %d bytes left in buffer", bytes);
         else
           ESP_LOGD(TAG, "Transmission successful (fast)");
-        this->flush_and_rx();
-        this->tx_phase_ = TxPhase::IDLE;
+        this->start_flush_rx_();
       } else if (millis() > this->tx_deadline_ms_) {
         ESP_LOGE(TAG, "Timed out waiting for TX: 0x%02x",
                  this->read_status(CC1101_MARCSTATE));
-        this->flush_and_rx();
-        this->tx_phase_ = TxPhase::IDLE;
+        this->start_flush_rx_();
       }
       break;
 
@@ -371,12 +374,27 @@ void Elero::advance_tx_() {
           ESP_LOGE(TAG, "Error transferring, %d bytes left in buffer", bytes);
         else
           ESP_LOGD(TAG, "Transmission successful");
-        this->flush_and_rx();  // return chip to clean RX state and clear received_
-        this->tx_phase_ = TxPhase::IDLE;
+        this->start_flush_rx_();  // return chip to clean RX state
       } else if (millis() > this->tx_deadline_ms_) {
         ESP_LOGE(TAG, "Timed out waiting for TX Done: 0x%02x",
                  this->read_status(CC1101_MARCSTATE));
-        this->flush_and_rx();
+        this->start_flush_rx_();
+      }
+      break;
+
+    case TxPhase::FLUSH_RX:
+      if (this->read_status(CC1101_MARCSTATE) == CC1101_MARCSTATE_IDLE) {
+        this->write_cmd(CC1101_SFRX);
+        this->write_cmd(CC1101_SFTX);
+        this->write_cmd(CC1101_SRX);
+        this->received_ = false;
+        this->tx_phase_ = TxPhase::IDLE;
+      } else if (millis() > this->tx_deadline_ms_) {
+        ESP_LOGE(TAG, "FLUSH_RX: timed out waiting for IDLE: 0x%02x",
+                 this->read_status(CC1101_MARCSTATE));
+        // Hard reset as last resort
+        this->write_cmd(CC1101_SRES);
+        this->received_ = false;
         this->tx_phase_ = TxPhase::IDLE;
       }
       break;
@@ -725,6 +743,15 @@ void Elero::interpret_msg() {
       it->second.last_seen_ms = millis();
       it->second.last_rssi = rssi;
       it->second.last_state = payload[6];
+      // Flush command queue on error states to prevent stale commands
+      if (payload[6] == ELERO_STATE_BLOCKING ||
+          payload[6] == ELERO_STATE_OVERHEATED ||
+          payload[6] == ELERO_STATE_TIMEOUT) {
+        ESP_LOGW(TAG, "Runtime blind 0x%06x reports %s — flushing command queue",
+                 src, elero_state_to_string(payload[6]));
+        while (!it->second.command_queue.empty())
+          it->second.command_queue.pop();
+      }
     }
     this->states_dirty_ = true;
   } else {

--- a/components/elero/elero.h
+++ b/components/elero/elero.h
@@ -102,6 +102,7 @@ enum class TxPhase : uint8_t {
   WAIT_CC_IDLE,    // SIDLE sent; polling MARCSTATE until CC1101 reaches IDLE
   WAIT_CC_TX,      // STX sent; polling MARCSTATE until CC1101 enters TX
   WAIT_DONE,       // TX in progress; waiting for GDO0 TX-end signal (received_ flag)
+  FLUSH_RX,        // SIDLE sent; waiting for IDLE before flushing FIFOs and entering RX
 };
 
 struct RawPacket {
@@ -293,6 +294,7 @@ class Elero : public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARIT
 
  private:
   void advance_tx_();
+  void start_flush_rx_();  // non-blocking: SIDLE → FLUSH_RX phase
   uint8_t count_bits(uint8_t byte);
   void calc_parity(uint8_t* msg);
   void add_r20_to_nibbles(uint8_t* msg, uint8_t r20, uint8_t start, uint8_t length);

--- a/components/elero/light/EleroLight.cpp
+++ b/components/elero/light/EleroLight.cpp
@@ -212,6 +212,15 @@ void EleroLight::set_rx_state(uint8_t state) {
         this->ignore_write_state_ = false;
       }
     }
+  } else if (state == ELERO_STATE_BLOCKING || state == ELERO_STATE_OVERHEATED ||
+             state == ELERO_STATE_TIMEOUT) {
+    ESP_LOGW(TAG, "Light 0x%06x reports %s", this->command_.blind_addr,
+             elero_state_to_string(state, true));
+    // Flush pending commands — device is in error, don't send more
+    while (!this->commands_to_send_.empty()) this->commands_to_send_.pop();
+    this->send_packets_ = 0;
+    this->send_retries_ = 0;
+    this->is_dimming_ = false;
   }
 }
 


### PR DESCRIPTION
- EleroCover: flush command queue, reset movement tracking, and schedule
  a 10s recovery poll when BLOCKING/OVERHEATED/TIMEOUT error states are
  received from the blind motor
- EleroCover: force cover to IDLE after ELERO_TIMEOUT_MOVEMENT (120s)
  expires with no RF feedback, preventing permanent stuck OPENING/CLOSING
- EleroLight: add explicit handling for error states (log warning, flush
  command queue, cancel dimming) instead of silently ignoring them
- Runtime blinds: flush command queue on error states to prevent stale
  commands from firing after the motor reports an error
- Replace blocking flush_and_rx() in advance_tx_() and loop() overflow
  with non-blocking FLUSH_RX TxPhase that polls CC1101 MARCSTATE once
  per loop tick instead of spin-waiting up to 100ms
- Guard received-packet processing against non-IDLE TX phases to avoid
  reading FIFOs during flush

https://claude.ai/code/session_01CPDebcAeA3bW3gqDaanfeC