### PR TITLE
Remove unused #include <algorithm> and ELERO_COMMAND_COVER_INT constant

### DIFF
--- a/components/elero/elero.cpp
+++ b/components/elero/elero.cpp
@@ -2,7 +2,6 @@
 #include "esphome/core/log.h"
 #include "esphome/core/helpers.h"
 #include <cstring>
-#include <algorithm>
 
 #ifdef USE_SENSOR
 #include "esphome/components/sensor/sensor.h"

--- a/components/elero/elero.h
+++ b/components/elero/elero.h
@@ -34,7 +34,6 @@ static const uint8_t ELERO_COMMAND_COVER_STOP = 0x10;
 static const uint8_t ELERO_COMMAND_COVER_UP = 0x20;
 static const uint8_t ELERO_COMMAND_COVER_TILT = 0x24;
 static const uint8_t ELERO_COMMAND_COVER_DOWN = 0x40;
-static const uint8_t ELERO_COMMAND_COVER_INT = 0x44;
 
 static const uint8_t ELERO_STATE_UNKNOWN = 0x00;
 static const uint8_t ELERO_STATE_TOP = 0x01;


### PR DESCRIPTION
- Remove `#include <algorithm>` from elero.cpp — no std::algorithm
  functions are used in this file
- Remove `ELERO_COMMAND_COVER_INT` (0x44) from elero.h — this constant
  is not referenced anywhere in the codebase

https://claude.ai/code/session_01K5uv6gBFoRPhJ6KSDKsVyZ