### PR TITLE
Improve RF reliability: fix ghost FIFO reads, add TX cooldown, smarter polling

### DIFF
--- a/components/elero/cover/EleroCover.cpp
+++ b/components/elero/cover/EleroCover.cpp
@@ -48,15 +48,39 @@ void EleroCover::loop() {
   uint32_t intvl = this->poll_intvl_;
   uint32_t now = millis();
   if(this->current_operation != COVER_OPERATION_IDLE) {
-    if(this->movement_start_ > 0 && (now - this->movement_start_) > ELERO_TIMEOUT_MOVEMENT) {
+    // Compute a tighter timeout when the travel duration is known:
+    // 3× the expected duration is generous enough to handle slow blinds
+    // but avoids the full 120 s hard timeout for typical 30 s movements.
+    uint32_t expected_dur_for_timeout = (this->current_operation == COVER_OPERATION_OPENING)
+                                            ? this->open_duration_
+                                            : this->close_duration_;
+    uint32_t effective_timeout = ELERO_TIMEOUT_MOVEMENT;  // default 120 s
+    if (expected_dur_for_timeout > 0) {
+      uint32_t travel_timeout = expected_dur_for_timeout * 3;
+      if (travel_timeout < effective_timeout)
+        effective_timeout = travel_timeout;
+    }
+    if(this->movement_start_ > 0 && (now - this->movement_start_) > effective_timeout) {
       // Force idle if movement timed out with no RF feedback
       ESP_LOGW(TAG, "Blind 0x%06x: movement timed out after %us with no RF feedback, forcing idle",
-               this->command_.blind_addr, ELERO_TIMEOUT_MOVEMENT / 1000);
+               this->command_.blind_addr, effective_timeout / 1000);
       this->current_operation = COVER_OPERATION_IDLE;
       this->movement_start_ = 0;
       this->publish_state();
     } else {
-      intvl = ELERO_POLL_INTERVAL_MOVING;  // Poll frequently while moving
+      // Determine expected travel duration for the current direction
+      uint32_t expected_dur = (this->current_operation == COVER_OPERATION_OPENING)
+                                  ? this->open_duration_
+                                  : this->close_duration_;
+      if (expected_dur > 0 &&
+          (now - this->movement_start_) > expected_dur + ELERO_POST_MOVEMENT_POLL_DELAY) {
+        // Travel time + post-movement poll already elapsed — blind should
+        // have responded by now.  Switch to a relaxed poll rate to reduce
+        // RF traffic while we wait for the 120 s movement timeout.
+        intvl = ELERO_POLL_INTERVAL_POST_TRAVEL;
+      } else {
+        intvl = ELERO_POLL_INTERVAL_MOVING;  // Poll frequently while moving
+      }
     }
   }
 

--- a/components/elero/elero.cpp
+++ b/components/elero/elero.cpp
@@ -78,11 +78,15 @@ void Elero::loop() {
   }
 
   if(this->received_ && this->tx_phase_ == TxPhase::IDLE) {
+    // Clear the flag immediately so we don't re-enter on the next loop()
+    // if no new packet arrives.  The ISR will set it again if another
+    // packet arrives during processing.
+    this->received_ = false;
     ESP_LOGD(TAG, "RF packet received, reading FIFO");
     uint8_t len = this->read_status(CC1101_RXBYTES);
     if(len & 0x80) { // overflow - FIFO data unreliable
       ESP_LOGV(TAG, "Rx overflow, flushing FIFOs");
-      this->start_flush_rx_();
+      this->flush_and_rx();
       return;
     }
     if(len & 0x7F) { // bytes available
@@ -302,6 +306,12 @@ bool Elero::transmit() {
     ESP_LOGD(TAG, "TX busy, deferring transmit");
     return false;
   }
+  // Enforce minimum RX dwell time after the last TX so the CC1101
+  // remains in RX long enough for blinds to send status responses.
+  if (this->last_tx_completed_ms_ > 0 &&
+      (millis() - this->last_tx_completed_ms_) < ELERO_MIN_RX_DWELL_MS) {
+    return false;  // silently defer — caller will retry next loop
+  }
   ESP_LOGD(TAG, "Starting TX (%d data bytes)", this->msg_tx_[0]);
   // Go to IDLE first so the subsequent STX is not subject to CCA.
   // (STX from RX with MCSM1 CCA_MODE=3 requires a clear channel, which
@@ -388,6 +398,7 @@ void Elero::advance_tx_() {
         this->write_cmd(CC1101_SRX);
         this->received_ = false;
         this->tx_phase_ = TxPhase::IDLE;
+        this->last_tx_completed_ms_ = millis();
       } else if (millis() > this->tx_deadline_ms_) {
         ESP_LOGE(TAG, "FLUSH_RX: timed out waiting for IDLE: 0x%02x",
                  this->read_status(CC1101_MARCSTATE));
@@ -395,6 +406,7 @@ void Elero::advance_tx_() {
         this->write_cmd(CC1101_SRES);
         this->received_ = false;
         this->tx_phase_ = TxPhase::IDLE;
+        this->last_tx_completed_ms_ = millis();
       }
       break;
   }

--- a/components/elero/elero.h
+++ b/components/elero/elero.h
@@ -61,6 +61,8 @@ static const uint32_t ELERO_POLL_INTERVAL_MOVING = 2000;  // poll every two seco
 static const uint32_t ELERO_DELAY_SEND_PACKETS = 50; // 50ms send delay between repeats
 static const uint32_t ELERO_TIMEOUT_MOVEMENT = 120000; // poll for up to two minutes while moving
 static const uint32_t ELERO_POST_MOVEMENT_POLL_DELAY = 5000; // poll 5s after open/close duration elapses
+static const uint32_t ELERO_MIN_RX_DWELL_MS = 150; // minimum RX dwell time after TX before next TX
+static const uint32_t ELERO_POLL_INTERVAL_POST_TRAVEL = 15000; // 15s poll rate after expected travel time
 
 static const uint8_t ELERO_SEND_RETRIES = 3;
 static const uint8_t ELERO_SEND_PACKETS = 2;
@@ -336,6 +338,7 @@ class Elero : public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARIT
   // Non-blocking TX state machine
   TxPhase  tx_phase_{TxPhase::IDLE};
   uint32_t tx_deadline_ms_{0};
+  uint32_t last_tx_completed_ms_{0};  // for enforcing RX dwell time
   // LittleFS persistent storage
   EleroStorage storage_;
   uint32_t last_state_save_ms_{0};


### PR DESCRIPTION
Four targeted fixes for RF communication reliability:

1. Clear received_ flag after RX processing (elero.cpp)
   The ISR-set flag was never cleared in the normal RX path, causing
   the loop to re-enter the FIFO handler dozens of times per packet
   with empty reads.  Now cleared immediately on entry; the ISR will
   re-set it if another packet arrives during processing.

2. Add global TX cooldown / RX dwell time (elero.h, elero.cpp)
   After each transmission completes, enforce a 150 ms minimum before
   accepting the next TX.  This guarantees the CC1101 stays in RX mode
   long enough for blinds to send status responses, breaking the
   TX-TX-TX chain that prevented reception when multiple covers polled
   simultaneously.

3. Reduce polling after expected travel time (EleroCover.cpp)
   Once open/close duration + 5 s post-movement poll have elapsed,
   switch from aggressive 2 s polling to a relaxed 15 s rate.  The
   blind should have responded by now; hammering every 2 s only
   saturates the air and prevents the response from getting through.

4. Tighter movement timeout (EleroCover.cpp)
   When travel duration is configured, use 3× that duration as the
   movement timeout instead of the fixed 120 s.  For a 31 s blind
   this means 93 s instead of 120 s, reducing the window of
   unnecessary polling.

https://claude.ai/code/session_01LbJfSD2nnsXqUQQJnvZRrJ