### PR TITLE
Fix Elero cover assumed state tracking

### DIFF
--- a/components/elero/cover/EleroCover.cpp
+++ b/components/elero/cover/EleroCover.cpp
@@ -175,7 +175,7 @@ cover::CoverTraits EleroCover::get_traits() {
   else
     traits.set_supports_position(false);
   traits.set_supports_toggle(true);
-  traits.set_is_assumed_state(true);
+  traits.set_is_assumed_state(false);
   traits.set_supports_tilt(this->supports_tilt_);
   return traits;
 }


### PR DESCRIPTION
## Summary
Changed the Elero cover component to report actual state instead of assumed state, improving state accuracy for cover position tracking.

## Key Changes
- Modified `EleroCover::get_traits()` to set `is_assumed_state` to `false` instead of `true`
  - This indicates that the cover's position state is based on actual feedback rather than assumptions
  - Allows Home Assistant to properly track and report the real state of Elero covers

## Implementation Details
The change affects how Home Assistant handles state reporting for Elero cover devices. By setting `is_assumed_state` to `false`, the component now indicates that it receives actual position feedback from the cover hardware, rather than relying on assumed state based on sent commands. This improves reliability and accuracy of cover status in automations and UI displays.

https://claude.ai/code/session_01UAH49WizfjSVBhs7oV12Ym