### PR TITLE
Fix TX reliability: detect TX completion via MARCSTATE when GDO0 fails

### DIFF
--- a/components/elero/elero.cpp
+++ b/components/elero/elero.cpp
@@ -223,15 +223,32 @@ void Elero::advance_tx() {
       if (marc == CC1101_MARCSTATE_TX) {
         this->tx_state_ = TxState::TRANSMITTING;
         this->tx_state_entered_ms_ = now;
+        this->gdo0_miss_count_ = 0;
       } else if (this->gdo0_fired_) {
         // GDO0 falling edge means the TX packet has been fully sent.  The
         // entire TX cycle (calibration + packet) completed before we could
         // observe MARCSTATE=TX — the radio already auto-transitioned to RX
         // (MCSM1 TXOFF_MODE=RX).  Skip straight to verification.
-        ESP_LOGD(TAG, "TX fast-path: completed during FIRING (marc=%s (0x%02x), %lums)",
+        ESP_LOGD(TAG, "TX fast-path: GDO0 fired during FIRING (marc=%s (0x%02x), %lums)",
                  marcstate_to_string(marc), marc, (unsigned long) elapsed);
         this->tx_state_ = TxState::VERIFYING;
         this->tx_state_entered_ms_ = now;
+        this->gdo0_miss_count_ = 0;
+      } else if (marc == CC1101_MARCSTATE_RX || marc == CC1101_MARCSTATE_TX_END) {
+        // The entire TX cycle completed before we could observe MARCSTATE=TX,
+        // and the GDO0 interrupt did not fire.  The radio already auto-
+        // transitioned to RX (MCSM1 TXOFF_MODE=RX).  Proceed to VERIFYING
+        // which confirms TXBYTES==0 for safety.
+        ESP_LOGD(TAG, "TX completed (no GDO0) during FIRING (marc=%s (0x%02x), %lums)",
+                 marcstate_to_string(marc), marc, (unsigned long) elapsed);
+        this->tx_state_ = TxState::VERIFYING;
+        this->tx_state_entered_ms_ = now;
+        if (++this->gdo0_miss_count_ == 10) {
+          ESP_LOGW(TAG, "GDO0 interrupt not firing during TX — check GDO0 pin wiring/configuration");
+        }
+      } else if (marc == CC1101_MARCSTATE_TXFIFO_UFLOW) {
+        ESP_LOGE(TAG, "TX FIFO underflow in FIRING");
+        this->tx_abort_();
       } else if (elapsed > TX_STATE_TIMEOUT_MS) {
         ESP_LOGE(TAG, "TX timeout in FIRING (marc=%s (0x%02x))", marcstate_to_string(marc), marc);
         this->tx_abort_();

--- a/components/elero/elero.h
+++ b/components/elero/elero.h
@@ -338,6 +338,7 @@ class Elero : public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARIT
   std::atomic<TxState> tx_state_{TxState::IDLE};
   uint32_t tx_state_entered_ms_{0};
   uint32_t last_tx_complete_ms_{0};
+  uint8_t gdo0_miss_count_{0};  // consecutive TX completions without GDO0
 
   uint8_t msg_rx_[CC1101_FIFO_LENGTH];
   uint8_t msg_tx_[CC1101_FIFO_LENGTH];


### PR DESCRIPTION
The FIRING state relied on either observing MARCSTATE=TX or the GDO0
falling-edge interrupt to detect TX progress. When GDO0 doesn't fire
(hardware wiring, GPIO conflict, or ISR issues), and the entire TX
cycle completes between loop() iterations, the radio is already back
in RX but neither detection path triggers — causing a 50ms timeout
on every TX attempt.

Add MARCSTATE-based fallback: if MARCSTATE shows RX (0x0d) or TX_END
(0x14) during FIRING, recognize that TX completed and proceed to
VERIFYING (which confirms TXBYTES==0 for safety). Also handle
TXFIFO_UFLOW as an immediate failure.

Add gdo0_miss_count_ to track consecutive TX completions without GDO0,
logging a warning after 10 misses to help diagnose pin wiring issues.

https://claude.ai/code/session_01HTbYRNyky4yBsLJn46wfag