### PR TITLE
Add configurable send_repeats and send_delay to hub config

### DIFF
--- a/components/elero/__init__.py
+++ b/components/elero/__init__.py
@@ -14,6 +14,8 @@ CONF_ELERO_ID = "elero_id"
 CONF_FREQ0 = "freq0"
 CONF_FREQ1 = "freq1"
 CONF_FREQ2 = "freq2"
+CONF_SEND_REPEATS = "send_repeats"
+CONF_SEND_DELAY = "send_delay"
 
 CONFIG_SCHEMA = (
     cv.Schema(
@@ -23,6 +25,8 @@ CONFIG_SCHEMA = (
             cv.Optional(CONF_FREQ0, default=0x7a): cv.hex_int_range(min=0x0, max=0xff),
             cv.Optional(CONF_FREQ1, default=0x71): cv.hex_int_range(min=0x0, max=0xff),
             cv.Optional(CONF_FREQ2, default=0x21): cv.hex_int_range(min=0x0, max=0xff),
+            cv.Optional(CONF_SEND_REPEATS, default=5): cv.int_range(min=1, max=20),
+            cv.Optional(CONF_SEND_DELAY, default="1ms"): cv.positive_time_period_milliseconds,
         }
     )
     .extend(cv.COMPONENT_SCHEMA)
@@ -40,6 +44,8 @@ async def to_code(config):
     cg.add(var.set_freq0(config[CONF_FREQ0]))
     cg.add(var.set_freq1(config[CONF_FREQ1]))
     cg.add(var.set_freq2(config[CONF_FREQ2]))
+    cg.add(var.set_send_repeats(config[CONF_SEND_REPEATS]))
+    cg.add(var.set_send_delay(config[CONF_SEND_DELAY].total_milliseconds))
 
     # Reserve a log listener slot so add_log_listener() works at runtime.
     # Required for ESPHome 2026.1.0+ (StaticVector migration).

--- a/components/elero/cover/EleroCover.cpp
+++ b/components/elero/cover/EleroCover.cpp
@@ -146,13 +146,13 @@ void EleroCover::handle_commands(uint32_t now) {
   // Don't attempt TX while the radio is busy — try again next loop()
   if (!this->parent_->is_tx_idle()) return;
 
-  if((now - this->last_command_) > ELERO_DELAY_SEND_PACKETS) {
+  if((now - this->last_command_) > this->parent_->get_send_delay()) {
     if(this->commands_to_send_.size() > 0) {
       this->command_.payload[4] = this->commands_to_send_.front();
       if(this->parent_->send_command(&this->command_)) {
         this->send_packets_++;
         this->send_retries_ = 0;
-        if(this->send_packets_ >= ELERO_SEND_PACKETS) {
+        if(this->send_packets_ >= this->parent_->get_send_repeats()) {
           this->commands_to_send_.pop();
           this->send_packets_ = 0;
           this->increase_counter();

--- a/components/elero/elero.cpp
+++ b/components/elero/elero.cpp
@@ -381,9 +381,13 @@ void Elero::drain_runtime_queues() {
       cmd.payload[1] = rb.payload_2;
       cmd.payload[4] = cmd_byte;
       if (this->send_command(&cmd)) {
-        rb.command_queue.pop();
-        rb.cmd_counter++;
-        if (rb.cmd_counter > 255) rb.cmd_counter = 1;
+        rb.send_packets_count++;
+        if (rb.send_packets_count >= this->send_repeats_) {
+          rb.command_queue.pop();
+          rb.send_packets_count = 0;
+          rb.cmd_counter++;
+          if (rb.cmd_counter > 255) rb.cmd_counter = 1;
+        }
       }
       break;  // Only one TX per loop iteration
     }
@@ -405,6 +409,7 @@ void Elero::dump_config() {
   ESP_LOGCONFIG(TAG, "Elero CC1101:");
   LOG_PIN("  GDO0 Pin: ", this->gdo0_pin_);
   ESP_LOGCONFIG(TAG, "  freq2: 0x%02x, freq1: 0x%02x, freq0: 0x%02x", this->freq2_, this->freq1_, this->freq0_);
+  ESP_LOGCONFIG(TAG, "  Send repeats: %d, send delay: %d ms", this->send_repeats_, this->send_delay_);
   ESP_LOGCONFIG(TAG, "  Registered covers: %d", this->address_to_cover_mapping_.size());
 }
 

--- a/components/elero/elero.h
+++ b/components/elero/elero.h
@@ -74,12 +74,12 @@ static const uint8_t ELERO_STATE_ON = 0x10;
 static const uint8_t ELERO_MAX_PACKET_SIZE = 57; // according to FCC documents
 
 static const uint32_t ELERO_POLL_INTERVAL_MOVING = 2000;  // poll every two seconds while moving
-static const uint32_t ELERO_DELAY_SEND_PACKETS = 50; // 50ms send delay between repeats
+static const uint32_t ELERO_DEFAULT_SEND_DELAY = 1; // 1ms default send delay between repeats
 static const uint32_t ELERO_TIMEOUT_MOVEMENT = 120000; // poll for up to two minutes while moving
 static const uint32_t ELERO_POST_MOVEMENT_POLL_DELAY = 5000; // poll 5s after open/close duration elapses
 
 static const uint8_t ELERO_SEND_RETRIES = 3;
-static const uint8_t ELERO_SEND_PACKETS = 2;
+static const uint8_t ELERO_DEFAULT_SEND_REPEATS = 5;
 static const uint8_t ELERO_MAX_COMMAND_QUEUE = 10; // max commands per blind to prevent OOM
 
 // Auto-stop reliability: repeat stop commands, compensate for TX latency, verify motor stopped
@@ -165,6 +165,7 @@ struct RuntimeBlind {
   uint8_t last_state{ELERO_STATE_UNKNOWN};
   uint8_t cmd_counter{1};
   std::queue<uint8_t> command_queue;
+  uint8_t send_packets_count{0};
 };
 
 const char *elero_state_to_string(uint8_t state);
@@ -331,6 +332,10 @@ class Elero : public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARIT
   void set_freq0(uint8_t freq) { freq0_ = freq; }
   void set_freq1(uint8_t freq) { freq1_ = freq; }
   void set_freq2(uint8_t freq) { freq2_ = freq; }
+  void set_send_repeats(uint8_t repeats) { send_repeats_ = repeats; }
+  void set_send_delay(uint32_t delay_ms) { send_delay_ = delay_ms; }
+  uint8_t get_send_repeats() const { return send_repeats_; }
+  uint32_t get_send_delay() const { return send_delay_; }
   void reinit_frequency(uint8_t freq2, uint8_t freq1, uint8_t freq0);
   uint8_t get_freq0() const { return freq0_; }
   uint8_t get_freq1() const { return freq1_; }
@@ -383,6 +388,8 @@ class Elero : public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARIT
   uint8_t freq0_{0x7a};
   uint8_t freq1_{0x71};
   uint8_t freq2_{0x21};
+  uint8_t send_repeats_{ELERO_DEFAULT_SEND_REPEATS};
+  uint32_t send_delay_{ELERO_DEFAULT_SEND_DELAY};
   InternalGPIOPin *gdo0_pin_{nullptr};
   std::map<uint32_t, EleroBlindBase*> address_to_cover_mapping_;
   std::map<uint32_t, EleroLightBase*> address_to_light_mapping_;

--- a/components/elero/light/EleroLight.cpp
+++ b/components/elero/light/EleroLight.cpp
@@ -147,13 +147,13 @@ void EleroLight::handle_commands(uint32_t now) {
   // Don't attempt TX while the radio is busy — try again next loop()
   if (!this->parent_->is_tx_idle()) return;
 
-  if ((now - this->last_command_) > ELERO_DELAY_SEND_PACKETS) {
+  if ((now - this->last_command_) > this->parent_->get_send_delay()) {
     if (!this->commands_to_send_.empty()) {
       this->command_.payload[4] = this->commands_to_send_.front();
       if (this->parent_->send_command(&this->command_)) {
         this->send_packets_++;
         this->send_retries_ = 0;
-        if (this->send_packets_ >= ELERO_SEND_PACKETS) {
+        if (this->send_packets_ >= this->parent_->get_send_repeats()) {
           this->commands_to_send_.pop();
           this->send_packets_ = 0;
           this->increase_counter();


### PR DESCRIPTION
Make RF command repetition count and inter-repeat delay globally
configurable via the elero hub YAML instead of hardcoded constants.
Defaults: 5 repeats, 1ms delay. Applies to covers, lights, and
runtime-adopted blinds.

https://claude.ai/code/session_01JKi5tPC6bqhL65QMdU7wrK