### PR TITLE
Add minimum packet length check to reject non-Elero RF noise early

### DIFF
--- a/components/elero/elero.cpp
+++ b/components/elero/elero.cpp
@@ -765,6 +765,19 @@ void Elero::interpret_msg() {
     return;
   }
 
+  // Minimum length: header fields extend to msg_rx_[16] (num_dests), so the
+  // payload portion (length) must be at least 17 bytes.  Shorter packets are
+  // non-Elero RF noise on the shared 868 MHz band — expected and harmless.
+  static const uint8_t ELERO_MIN_PACKET_SIZE = 17;
+  if (length < ELERO_MIN_PACKET_SIZE) {
+    ESP_LOGD(TAG, "Received non-Elero packet: too short (%d bytes)", length);
+    if (this->packet_dump_pending_update_) {
+      this->mark_last_raw_packet_(false, "too_short");
+      this->packet_dump_pending_update_ = false;
+    }
+    return;
+  }
+
   uint8_t cnt = this->msg_rx_[1];
   uint8_t typ = this->msg_rx_[2];
   uint8_t typ2 = this->msg_rx_[3];


### PR DESCRIPTION
Short packets (length < 17) from other 868 MHz devices pass the FIFO
length check but fail later when interpret_msg() reads header fields
beyond the packet boundary (e.g. msg_rx_[16] for num_dests). This
caused misleading ERROR-level "too many destinations" and "dests_len
too long" messages from stale buffer data.

Add an early minimum length check (17 bytes = header up to num_dests)
that rejects these packets at DEBUG level before any header parsing,
since they are expected RF noise on the shared ISM band.

https://claude.ai/code/session_01UbWQTmxiCbwJyPRXFdcTV2