### PR TITLE
Add minimum_chip_revision: 3.1 to reduce binary size

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ esphome:
 
 esp32:
   board: esp32dev
+  variant: esp32
+  minimum_chip_revision: 3.1
 
 # WLAN-Konfiguration
 wifi:

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -108,6 +108,8 @@ esphome:
 
 esp32:
   board: esp32dev
+  variant: esp32
+  minimum_chip_revision: 3.1
 
 wifi:
   ssid: "DEIN_WLAN_NAME"
@@ -308,6 +310,8 @@ esphome:
 
 esp32:
   board: esp32dev
+  variant: esp32
+  minimum_chip_revision: 3.1
 
 wifi:
   ssid: !secret wifi_ssid

--- a/example.yaml
+++ b/example.yaml
@@ -1,3 +1,9 @@
+# Set minimum_chip_revision to reduce binary size (removes compat code for older chips)
+esp32:
+  board: esp32dev
+  variant: esp32
+  minimum_chip_revision: 3.1
+
 external_components:
   - source: github://pfriedrich84/esphome-elero
 


### PR DESCRIPTION
Set esp32 minimum_chip_revision to 3.1 in example.yaml and all
documentation config snippets to eliminate compatibility code for
older chip revisions, reducing firmware binary size.

https://claude.ai/code/session_01FB85iZcx4yNkTLWJGQatvX