### PR TITLE
Fix destructor override error: Component base class has no virtual destructor

### DIFF
--- a/components/elero/elero.h
+++ b/components/elero/elero.h
@@ -281,7 +281,7 @@ class Elero : public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARIT
                                     spi::CLOCK_PHASE_LEADING, spi::DATA_RATE_2MHZ>,
                                     public Component {
  public:
-  ~Elero() override;
+  ~Elero();
   void setup() override;
   void loop() override;
 


### PR DESCRIPTION
Remove `override` keyword from `~Elero()` since neither `spi::SPIDevice`
nor `Component` declares a virtual destructor to override.

https://claude.ai/code/session_01SvPTGmHjL5dyetPSk68x9j