### PR TITLE
Add SPI health detection for ESP32 strapping pin issues

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -655,6 +655,7 @@ There are no automated tests in this repository. Validation is done manually on 
 ## Common Pitfalls
 
 - **Wrong frequency**: Most European Elero motors use 868.35 MHz (`freq0=0x7a`). Some use 868.95 MHz (`freq0=0xc0`). If discovery finds nothing, try the alternate frequency. Use the `/elero/api/frequency/set` endpoint to test at runtime.
+- **ESP32 strapping pins and SPI**: Do **not** use GPIO12 as SPI MISO (or any SPI signal). GPIO12 is a strapping pin that controls VDD_SDIO voltage at boot. If the CC1101 module pulls it HIGH, VDD_SDIO is set to 1.8V, breaking all SPI communication (symptoms: all SPI write verify fail with `rc=-16`, MARCSTATE stuck at `0x00`). Safe SPI pins: CLK=GPIO18, MISO=GPIO19, MOSI=GPIO23. Avoid GPIO0, GPIO2, GPIO5, GPIO12, GPIO15 for SPI signals. The component detects persistent SPI failure at runtime and marks itself as failed with a diagnostic error message.
 - **SPI conflicts**: The CC1101 CS pin must not be shared with any other SPI device.
 - **Using `web_server:` instead of `web_server_base:`**: Adding `web_server:` to your YAML re-enables the default ESPHome entity UI at `/`. Use `web_server_base:` (or rely on its auto-load via `elero_web`) to serve only the Elero UI at `/elero`. Navigating to `/` will redirect automatically to `/elero`.
 - **Position tracking**: Leave `open_duration` and `close_duration` at `0s` if you only need open/close without position — setting incorrect durations causes wrong position estimates. Both must be set or both zero (enforced by `_validate_duration_consistency`).

--- a/components/elero/__init__.py
+++ b/components/elero/__init__.py
@@ -1,10 +1,19 @@
+import logging
+
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome import pins
 from esphome.components import spi
 from esphome.const import CONF_ID
 
+_LOGGER = logging.getLogger(__name__)
+
 DEPENDENCIES = ["spi"]
+
+# ESP32 strapping pins that can cause boot issues when used for SPI or I/O.
+# GPIO12 (MTDI) is especially problematic: if pulled HIGH at boot by an SPI
+# device, VDD_SDIO is set to 1.8V, breaking all SPI communication.
+ESP32_STRAPPING_PINS = {0, 2, 5, 12, 15}
 
 elero_ns = cg.esphome_ns.namespace("elero")
 elero = elero_ns.class_("Elero", spi.SPIDevice, cg.Component)
@@ -32,6 +41,30 @@ CONFIG_SCHEMA = (
     .extend(cv.COMPONENT_SCHEMA)
     .extend(spi.spi_device_schema(cs_pin_required=True))
 )
+
+
+def _warn_strapping_pins(config):
+    """Warn if gdo0_pin or cs_pin uses an ESP32 strapping pin."""
+    for key in (CONF_GDO0_PIN, "cs_pin"):
+        pin_conf = config.get(key)
+        if pin_conf is None:
+            continue
+        # pin_conf may be a dict with "number" or an int directly
+        pin_num = pin_conf.get("number") if isinstance(pin_conf, dict) else pin_conf
+        if isinstance(pin_num, int) and pin_num in ESP32_STRAPPING_PINS:
+            _LOGGER.warning(
+                "GPIO%d (%s) is an ESP32 strapping pin. If used for SPI "
+                "(especially GPIO12 as MISO), it can cause VDD_SDIO voltage "
+                "issues that break CC1101 communication. Consider using "
+                "non-strapping pins (e.g. CLK=18, MISO=19, MOSI=23, CS=5, "
+                "GDO0=26).",
+                pin_num,
+                key,
+            )
+    return config
+
+
+FINAL_VALIDATE_SCHEMA = _warn_strapping_pins
 
 
 async def to_code(config):

--- a/components/elero/elero.cpp
+++ b/components/elero/elero.cpp
@@ -176,6 +176,10 @@ Elero::~Elero() {
 }
 
 void Elero::loop() {
+  // Skip all processing if SPI is permanently broken (e.g. strapping pin issue).
+  if (this->spi_failed_)
+    return;
+
   // 1. ALWAYS process pending RX packets first (highest priority).
   //    Only safe when not mid-TX — process_rx() ignores stale rx_ready_
   //    flags by only running when TX is idle or in cooldown.
@@ -370,8 +374,10 @@ void Elero::check_radio_state_() {
   uint8_t marc = this->read_status(CC1101_MARCSTATE) & 0x1F;
 
   // RX is the expected state when tx_state_ is IDLE
-  if (marc == CC1101_MARCSTATE_RX)
+  if (marc == CC1101_MARCSTATE_RX) {
+    this->consecutive_watchdog_failures_ = 0;
     return;
+  }
 
   // Transient calibration / synthesizer states — let them complete
   if (marc >= CC1101_MARCSTATE_VCOON_MC && marc <= CC1101_MARCSTATE_ENDCAL)
@@ -399,6 +405,7 @@ void Elero::check_radio_state_() {
   if (marc == CC1101_MARCSTATE_IDLE) {
     ESP_LOGW(TAG, "Radio watchdog: stuck in IDLE, restarting RX");
     this->watchdog_recovery_count_++;
+    this->consecutive_watchdog_failures_ = 0;  // IDLE is a valid CC1101 state, not SPI failure
     this->write_cmd(CC1101_SRX);
     return;
   }
@@ -409,6 +416,21 @@ void Elero::check_radio_state_() {
   // SRES followed by full register configuration is needed.
   ESP_LOGW(TAG, "Radio watchdog: unexpected state 0x%02x, full reinit", marc);
   this->watchdog_recovery_count_++;
+  this->consecutive_watchdog_failures_++;
+
+  // If the watchdog has failed 3+ times in a row without recovery, SPI is
+  // likely permanently broken (e.g. GPIO12 strapping pin issue).  Stop
+  // retrying to avoid flooding the log.
+  if (this->consecutive_watchdog_failures_ >= 3) {
+    ESP_LOGE(TAG, "Radio watchdog: %d consecutive failures — SPI appears permanently broken.",
+             this->consecutive_watchdog_failures_);
+    ESP_LOGE(TAG, "  If GPIO12 is used for SPI MISO, it may be pulling VDD_SDIO to 1.8V at boot.");
+    ESP_LOGE(TAG, "  Use non-strapping pins for SPI (e.g. CLK=18, MISO=19, MOSI=23).");
+    this->spi_failed_ = true;
+    this->mark_failed();
+    return;
+  }
+
   this->reset();
   this->init();
 }
@@ -536,6 +558,10 @@ void Elero::dump_config() {
   ESP_LOGCONFIG(TAG, "  freq2: 0x%02x, freq1: 0x%02x, freq0: 0x%02x", this->freq2_, this->freq1_, this->freq0_);
   ESP_LOGCONFIG(TAG, "  Send repeats: %d, send delay: %d ms", this->send_repeats_, this->send_delay_);
   ESP_LOGCONFIG(TAG, "  RadioLib: standby() + SPI register access with verify-readback");
+  if (this->spi_failed_) {
+    ESP_LOGCONFIG(TAG, "  SPI Status: FAILED — CC1101 communication broken");
+    ESP_LOGCONFIG(TAG, "  Check SPI pin assignments — avoid ESP32 strapping pins (GPIO0/2/5/12/15)");
+  }
   ESP_LOGCONFIG(TAG, "  Registered covers: %d", this->address_to_cover_mapping_.size());
 }
 
@@ -569,6 +595,25 @@ void Elero::setup() {
   this->gdo0_pin_->attach_interrupt(Elero::interrupt, this, gpio::INTERRUPT_FALLING_EDGE);
   this->reset();
   this->init();
+
+  // SPI health check: verify that register writes actually stick by reading
+  // back a known config register.  If SPI is completely broken (e.g. due to
+  // GPIO12 strapping pin pulling VDD_SDIO to 1.8V), every read returns 0x00
+  // or 0xFF and the radio can never initialize.
+  uint8_t test_val = this->read_reg(CC1101_FREQ2);
+  if (test_val != this->freq2_) {
+    ESP_LOGE(TAG, "SPI health check FAILED: wrote 0x%02x to FREQ2, read back 0x%02x",
+             this->freq2_, test_val);
+    ESP_LOGE(TAG, "CC1101 SPI communication is broken — the radio is non-functional.");
+    ESP_LOGE(TAG, "Common cause: GPIO12 is an ESP32 strapping pin that controls flash voltage.");
+    ESP_LOGE(TAG, "  If GPIO12 is used as SPI MISO, the CC1101 can pull it HIGH at boot,");
+    ESP_LOGE(TAG, "  setting VDD_SDIO to 1.8V and breaking all SPI communication.");
+    ESP_LOGE(TAG, "  Solution: use non-strapping pins for SPI (e.g. CLK=18, MISO=19, MOSI=23).");
+    ESP_LOGE(TAG, "  ESP32 strapping pins to avoid: GPIO0, GPIO2, GPIO5, GPIO12, GPIO15.");
+    this->spi_failed_ = true;
+    this->mark_failed();
+    return;
+  }
 
 #ifdef USE_LOGGER
   // Forward all ESP_LOG messages into the ring buffer so the web UI Log tab
@@ -1301,7 +1346,9 @@ void Elero::track_discovered_blind(uint32_t src, uint32_t remote, uint8_t channe
 }
 
 bool Elero::send_command(t_elero_command *cmd) {
-  // Reject if a TX is already in progress — caller should retry next loop.
+  // Reject if SPI is permanently broken or TX is already in progress.
+  if (this->spi_failed_)
+    return false;
   if (this->tx_state_.load(std::memory_order_acquire) != TxState::IDLE)
     return false;
 

--- a/components/elero/elero.h
+++ b/components/elero/elero.h
@@ -465,6 +465,10 @@ class Elero : public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARIT
   uint32_t tx_count_{0};
   uint32_t watchdog_recovery_count_{0};
 
+  // SPI health tracking: detect persistent SPI failures (e.g. strapping pin issues)
+  bool spi_failed_{false};            // set when SPI is permanently broken
+  uint8_t consecutive_watchdog_failures_{0};  // consecutive check_radio_state_ failures
+
   // RX overflow recovery: rate-limit flush attempts and escalate to full reinit
   uint32_t last_rx_overflow_ms_{0};
   uint8_t rx_overflow_count_{0};

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -59,6 +59,10 @@ GDO0 ──────>    GPIO26
 
 > **WARNUNG:** CC1101 arbeitet mit **3.3V**. Niemals an 5V anschließen!
 
+> **WICHTIG:** Verwende **keine ESP32 Strapping-Pins** (GPIO0, GPIO2, GPIO5, GPIO12, GPIO15) für die SPI-Leitungen (SCK, MOSI, MISO). Besonders **GPIO12 als MISO** ist problematisch: Das CC1101-Modul kann GPIO12 beim Boot auf HIGH ziehen, was VDD_SDIO auf 1.8V setzt und die gesamte SPI-Kommunikation zerstört. Die oben empfohlenen Pins (GPIO18/23/19) sind sicher. GPIO5 für CSN ist akzeptabel, da es als Chip-Select nur kurz aktiv ist.
+>
+> **IMPORTANT:** Do **not** use ESP32 strapping pins (GPIO0, GPIO2, GPIO5, GPIO12, GPIO15) for SPI signals (SCK, MOSI, MISO). **GPIO12 as MISO** is especially problematic: the CC1101 module can pull GPIO12 HIGH at boot, setting VDD_SDIO to 1.8V and breaking all SPI communication. The recommended pins above (GPIO18/23/19) are safe.
+
 ### Schritt 2.2: Verkabelung prüfen
 
 Prüfe alle Verbindungen nochmals:

--- a/example.yaml
+++ b/example.yaml
@@ -7,6 +7,9 @@ esp32:
 external_components:
   - source: github://pfriedrich84/esphome-elero
 
+# IMPORTANT: Avoid ESP32 strapping pins (GPIO0, GPIO2, GPIO5, GPIO12, GPIO15)
+# for SPI signals. GPIO12 as MISO is especially problematic — the CC1101 can
+# pull it HIGH at boot, setting VDD_SDIO to 1.8V and breaking all SPI.
 spi:
   clk_pin: GPIO18
   mosi_pin: GPIO23


### PR DESCRIPTION
## Summary
This PR adds robust detection and handling of SPI communication failures caused by ESP32 strapping pin misconfigurations, particularly GPIO12 being used as SPI MISO. When GPIO12 is pulled HIGH at boot by the CC1101 module, it sets VDD_SDIO to 1.8V, breaking all SPI communication. The component now detects this condition early and gracefully stops retrying instead of flooding logs.

## Key Changes

- **Early SPI health check in setup()**: Verifies that register writes actually stick by reading back a known config register (FREQ2). If the read value doesn't match the written value, SPI is marked as permanently failed.

- **Watchdog failure tracking**: Added `consecutive_watchdog_failures_` counter to detect persistent radio state issues. When 3+ consecutive failures occur without recovery, the component assumes SPI is permanently broken and stops retrying.

- **Graceful failure handling**: 
  - Added `spi_failed_` flag to skip all processing when SPI is broken
  - `loop()` returns early if SPI is failed
  - `send_command()` rejects commands if SPI is failed
  - `check_radio_state_()` resets the failure counter on successful RX or valid IDLE state

- **Enhanced logging**: Added detailed error messages explaining the GPIO12 strapping pin issue and recommending safe pin alternatives (GPIO18/23/19 for CLK/MOSI/MISO).

- **Configuration validation**: Added Python-level warnings in `__init__.py` to alert users at config time if they're using strapping pins for GDO0 or CS pins.

- **Documentation updates**: Added warnings in INSTALLATION.md and example.yaml about avoiding ESP32 strapping pins for SPI signals.

## Implementation Details

- The SPI health check compares the written FREQ2 register value against what's read back. A mismatch indicates broken SPI communication.
- Consecutive watchdog failures are reset whenever the radio successfully enters RX state or recovers from IDLE, ensuring transient issues don't trigger false positives.
- The component calls `mark_failed()` when SPI is detected as broken, properly integrating with ESPHome's component lifecycle.
- All error messages include actionable guidance about GPIO12 and recommended safe pin assignments.

https://claude.ai/code/session_019UZqYGHLXxQrTGZDhy5qyU