### PR TITLE
Improve TX state handling and error diagnostics in Elero CC1101

### DIFF
--- a/components/elero/elero.cpp
+++ b/components/elero/elero.cpp
@@ -268,11 +268,14 @@ void Elero::advance_tx() {
       // TX completion: CC1101 auto-transitions to RX (MCSM1 TXOFF_MODE=0x3).
       // Detect by polling MARCSTATE — when it leaves TX the packet is sent.
       uint8_t marc = this->read_status(CC1101_MARCSTATE) & 0x1F;
-      if (marc == CC1101_MARCSTATE_TX) {
-        // Still transmitting — check for timeout
+      if (marc == CC1101_MARCSTATE_TX ||
+          marc == CC1101_MARCSTATE_STARTCAL ||
+          marc == CC1101_MARCSTATE_FSTXON) {
+        // Still in TX pipeline — radio may be calibrating before TX (STARTCAL),
+        // actively transmitting (TX), or waiting to transmit (FSTXON).
         if (elapsed > TX_STATE_TIMEOUT_MS) {
-          ESP_LOGW(TAG, "TX timeout in TRANSMITTING (%lums), aborting",
-                   (unsigned long) elapsed);
+          ESP_LOGW(TAG, "TX timeout in TRANSMITTING (%lums, marc=%s), aborting",
+                   (unsigned long) elapsed, marcstate_to_string(marc));
           this->tx_abort_();
         }
       } else if (marc == CC1101_MARCSTATE_TXFIFO_UFLOW) {
@@ -289,10 +292,9 @@ void Elero::advance_tx() {
           this->tx_state_entered_ms_ = now;
           this->last_tx_complete_ms_ = now;
         } else {
-          // FIFO not empty — packet was never sent.  Most likely cause is CCA
-          // (Clear Channel Assessment) rejection: the channel was busy so the
-          // CC1101 returned to RX without transmitting.
-          ESP_LOGW(TAG, "TX failed: %d bytes still in FIFO (marc=%s) — likely CCA rejection, will retry",
+          // FIFO not empty — packet was never sent.  The radio left the TX
+          // pipeline without draining the FIFO (unexpected state transition).
+          ESP_LOGW(TAG, "TX failed: %d bytes still in FIFO (marc=%s) — packet not transmitted, will retry",
                    bytes, marcstate_to_string(marc));
           this->tx_abort_();
         }


### PR DESCRIPTION
## Summary
Enhanced the TX state machine in the Elero CC1101 driver to better handle intermediate radio states during transmission and provide more informative error logging.

## Key Changes
- **Expanded TX pipeline state detection**: Now recognizes `STARTCAL` (calibration) and `FSTXON` (waiting to transmit) states in addition to `TX`, providing more accurate detection of when the radio is actively in the transmission pipeline
- **Improved timeout diagnostics**: Added `marcstate_to_string(marc)` output to TX timeout log messages to help identify which specific state caused the timeout
- **Clarified error messaging**: Updated the FIFO underflow error message to more accurately describe the failure mode (unexpected state transition) rather than assuming CCA rejection, making it clearer that the packet was not transmitted due to an unexpected radio state change
- **Enhanced code comments**: Improved documentation explaining the different states the radio can be in during TX and what each state represents

## Implementation Details
The changes recognize that the CC1101 radio can transition through multiple states during transmission (calibration → waiting → transmitting), and the driver should account for all of these when determining if transmission is still in progress. This prevents premature timeout detection and provides better visibility into transmission failures through enhanced logging.

https://claude.ai/code/session_01VM6nqTxS2UXRV6jPjhb4Lc