### PR TITLE
Detect and block GPIO12 SPI usage to prevent VDD_SDIO voltage collapse

### DIFF
--- a/components/elero/__init__.py
+++ b/components/elero/__init__.py
@@ -43,15 +43,30 @@ CONFIG_SCHEMA = (
 )
 
 
-def _warn_strapping_pins(config):
-    """Warn if gdo0_pin or cs_pin uses an ESP32 strapping pin."""
+def _validate_strapping_pins(config):
+    """Block GPIO12 for SPI signals; warn about other strapping pins."""
     for key in (CONF_GDO0_PIN, "cs_pin"):
         pin_conf = config.get(key)
         if pin_conf is None:
             continue
         # pin_conf may be a dict with "number" or an int directly
         pin_num = pin_conf.get("number") if isinstance(pin_conf, dict) else pin_conf
-        if isinstance(pin_num, int) and pin_num in ESP32_STRAPPING_PINS:
+        if not isinstance(pin_num, int):
+            continue
+        # GPIO12 is catastrophic for any SPI signal — block compilation.
+        # It controls VDD_SDIO voltage at boot; if the CC1101 pulls it HIGH,
+        # VDD_SDIO locks at 1.8V and breaks all SPI communication permanently.
+        if pin_num == 12:
+            raise cv.Invalid(
+                f"GPIO12 cannot be used for {key} (ESP32 strapping pin controlling "
+                f"VDD_SDIO). If the CC1101 pulls GPIO12 HIGH at boot, VDD_SDIO is "
+                f"set to 1.8V, breaking all SPI communication (symptoms: "
+                f"'SPI write verify failed: rc=-16', MARCSTATE stuck at 0x00). "
+                f"Use non-strapping pins instead: CLK=GPIO18, MISO=GPIO19, "
+                f"MOSI=GPIO23, CS=GPIO5, GDO0=GPIO26."
+            )
+        # Other strapping pins — warn but allow (e.g. GPIO5 as CS is safe).
+        if pin_num in ESP32_STRAPPING_PINS:
             _LOGGER.warning(
                 "GPIO%d (%s) is an ESP32 strapping pin. If used for SPI "
                 "(especially GPIO12 as MISO), it can cause VDD_SDIO voltage "
@@ -64,7 +79,7 @@ def _warn_strapping_pins(config):
     return config
 
 
-FINAL_VALIDATE_SCHEMA = _warn_strapping_pins
+FINAL_VALIDATE_SCHEMA = _validate_strapping_pins
 
 
 async def to_code(config):

--- a/components/elero/elero.cpp
+++ b/components/elero/elero.cpp
@@ -174,6 +174,8 @@ void dispatch_commands(Elero *parent, std::queue<uint8_t> &queue,
                        bool &queue_full_published, uint32_t now,
                        const char *tag, uint32_t blind_addr,
                        void (*increase_counter_fn)(void *ctx), void *ctx) {
+  // Skip immediately if hub SPI is permanently broken — no point retrying.
+  if (parent->is_failed()) return;
   if (!parent->is_tx_idle()) return;
 
   if ((now - last_command) > parent->get_send_delay()) {
@@ -1481,14 +1483,31 @@ bool Elero::send_command(t_elero_command *cmd) {
   // not subject to CCA (Elero motors actively transmit, causing CCA failures).
   this->radio_->standby();
 
-  // Verify we actually reached IDLE — if not, radio is unresponsive
+  // Verify we actually reached IDLE — if not, radio is unresponsive.
+  // Track consecutive reinit failures to detect permanent SPI breakage early
+  // (e.g. GPIO12 strapping pin) without waiting for the 5-second watchdog.
   uint8_t marc = this->read_status(CC1101_MARCSTATE) & 0x1F;
   if (marc != CC1101_MARCSTATE_IDLE) {
-    ESP_LOGW(TAG, "send_command: radio not in IDLE (marc=0x%02x), reinitializing", marc);
+    this->send_cmd_reinit_failures_++;
+    if (this->send_cmd_reinit_failures_ >= 3) {
+      // SPI is permanently broken — stop retrying to avoid log spam.
+      if (!this->spi_failed_) {
+        ESP_LOGE(TAG, "send_command: %d consecutive reinit failures — SPI appears permanently broken.",
+                 this->send_cmd_reinit_failures_);
+        ESP_LOGE(TAG, "  If GPIO12 is used for SPI MISO, it may be pulling VDD_SDIO to 1.8V at boot.");
+        ESP_LOGE(TAG, "  Use non-strapping pins for SPI (e.g. CLK=18, MISO=19, MOSI=23).");
+        this->spi_failed_ = true;
+        this->mark_failed();
+      }
+      return false;
+    }
+    ESP_LOGW(TAG, "send_command: radio not in IDLE (marc=0x%02x), reinitializing (%d/%d)",
+             marc, this->send_cmd_reinit_failures_, 3);
     this->reset();
     this->init();
     return false;
   }
+  this->send_cmd_reinit_failures_ = 0;
 
   // Flush both FIFOs (valid in IDLE state per CC1101 spec): TX for a clean
   // slate, RX to discard any partial packet data from the reception that

--- a/components/elero/elero.h
+++ b/components/elero/elero.h
@@ -490,6 +490,7 @@ class Elero : public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARIT
   // SPI health tracking: detect persistent SPI failures (e.g. strapping pin issues)
   bool spi_failed_{false};            // set when SPI is permanently broken
   uint8_t consecutive_watchdog_failures_{0};  // consecutive check_radio_state_ failures
+  uint8_t send_cmd_reinit_failures_{0};  // consecutive send_command() reinit failures
 
   // RX overflow recovery: rate-limit flush attempts and escalate to full reinit
   uint32_t last_rx_overflow_ms_{0};


### PR DESCRIPTION
## Summary
This PR adds validation and detection logic to prevent GPIO12 from being used for SPI signals on ESP32, which causes permanent SPI communication failure by collapsing VDD_SDIO voltage to 1.8V at boot. The changes include compile-time validation, runtime detection of SPI failures, and early termination of retry attempts when permanent breakage is detected.

## Key Changes

- **Compile-time validation** (`components/elero/__init__.py`):
  - Renamed `_warn_strapping_pins()` to `_validate_strapping_pins()` to reflect stricter behavior
  - GPIO12 now raises a `cv.Invalid` exception during config validation, blocking compilation entirely
  - Other ESP32 strapping pins still generate warnings but allow compilation
  - Added detailed error message explaining the VDD_SDIO voltage collapse mechanism and recommending safe pin alternatives

- **Runtime SPI failure detection** (`components/elero/elero.cpp`):
  - Added `send_cmd_reinit_failures_` counter to track consecutive radio reinitialization failures in `send_command()`
  - After 3 consecutive failures, marks the component as failed and stops retry attempts to prevent log spam
  - Added early exit in `dispatch_commands()` if SPI is already marked as permanently failed
  - Enhanced logging to show failure count and explain GPIO12 as a likely cause

- **State tracking** (`components/elero/elero.h`):
  - Added `send_cmd_reinit_failures_` member variable to track consecutive reinit failures

## Implementation Details

The solution uses a two-layer defense:
1. **Preventive**: Block GPIO12 at compile time with a clear explanation of why and what pins to use instead
2. **Detective**: At runtime, detect when SPI becomes unresponsive (MARCSTATE not reaching IDLE) and fail fast after 3 attempts rather than retrying indefinitely

This avoids the 5-second watchdog delay for detecting permanent SPI breakage and prevents log spam from repeated failed reinit attempts.

https://claude.ai/code/session_01XYUFfFt5UQTyNQR3qpYYYm