### PR TITLE
Merge pull request #116 from pfriedrich84/claude/fix-radiolib-compilation-ZtVd9

### DIFF
--- a/components/elero/cover/EleroCover.cpp
+++ b/components/elero/cover/EleroCover.cpp
@@ -89,6 +89,8 @@ void EleroCover::loop() {
       ESP_LOGW(TAG, "Stop verification exhausted %d retries for blind 0x%06x",
                ELERO_STOP_VERIFY_MAX_RETRIES, this->command_.blind_addr);
       this->stop_verify_at_ = 0;
+      this->stop_trigger_ms_ = 0;
+      this->parent_->set_stop_urgent(false);
 #ifdef USE_TEXT_SENSOR
       this->parent_->publish_text_sensor_state(this->command_.blind_addr, "stop_failed");
 #endif
@@ -105,12 +107,19 @@ void EleroCover::loop() {
     if(this->is_at_target()) {
       ESP_LOGI(TAG, "Blind 0x%06x reached target (pos=%.2f, target=%.2f), sending stop",
                this->command_.blind_addr, this->position, this->target_position_);
+      // Record position at stop trigger for post-verification correction
+      this->stop_trigger_position_ = this->position;
+      this->stop_trigger_ms_ = now;
+      // Signal other covers to defer their non-stop commands
+      this->parent_->set_stop_urgent(true);
       // Clear queue so stop goes out immediately (mirrors manual stop behavior)
       while (!this->commands_to_send_.empty())
         this->commands_to_send_.pop();
-      // Send stop multiple times for RF reliability
-      for (uint8_t i = 0; i < ELERO_STOP_REPEAT_COUNT; i++)
-        this->commands_to_send_.push(this->command_stop_);
+      // Send stop via priority queue for immediate processing.
+      // Reduced from 2 to 1 stop command — verification loop re-sends if needed.
+      this->command_.payload[4] = this->command_stop_;
+      this->parent_->send_command_priority(&this->command_);
+      this->increase_counter();
       this->current_operation = COVER_OPERATION_IDLE;
       this->target_position_ = COVER_OPEN;
       // Schedule verification poll to confirm motor actually stopped
@@ -137,17 +146,22 @@ bool EleroCover::is_at_target() {
   if((this->target_position_ == COVER_OPEN) || (this->target_position_ == COVER_CLOSED))
     return false;
 
-  // Compensate for TX pipeline latency: trigger stop slightly early so the
-  // RF packet reaches the motor before it overshoots the target position.
+  // Dynamic TX latency compensation: base 300ms + 15ms per pending TX queue entry.
+  // With multiple covers, the queue may hold other covers' packets that delay our
+  // stop command.  The priority queue mitigates this, but we still compensate for
+  // any residual latency from in-flight TX.
+  uint32_t queue_depth = this->parent_->get_tx_queue_depth();
+  uint32_t compensation_ms = ELERO_TX_LATENCY_COMPENSATION_MS + (queue_depth * 15);
+
   float margin = 0.0f;
   switch (this->current_operation) {
     case COVER_OPERATION_OPENING:
       if (this->open_duration_ > 0)
-        margin = static_cast<float>(ELERO_TX_LATENCY_COMPENSATION_MS) / this->open_duration_;
+        margin = static_cast<float>(compensation_ms) / this->open_duration_;
       return this->position >= (this->target_position_ - margin);
     case COVER_OPERATION_CLOSING:
       if (this->close_duration_ > 0)
-        margin = static_cast<float>(ELERO_TX_LATENCY_COMPENSATION_MS) / this->close_duration_;
+        margin = static_cast<float>(compensation_ms) / this->close_duration_;
       return this->position <= (this->target_position_ + margin);
     case COVER_OPERATION_IDLE:
     default:
@@ -263,18 +277,35 @@ void EleroCover::set_rx_state(uint8_t state) {
   if (this->stop_verify_retries_ < ELERO_STOP_VERIFY_MAX_RETRIES) {
     if (state == ELERO_STATE_MOVING_UP || state == ELERO_STATE_MOVING_DOWN ||
         state == ELERO_STATE_START_MOVING_UP || state == ELERO_STATE_START_MOVING_DOWN) {
-      // Motor is still moving — re-send stop
+      // Motor is still moving — re-send stop via priority queue
       this->stop_verify_retries_++;
       ESP_LOGW(TAG, "Blind 0x%06x still moving after stop, retry #%d",
                this->command_.blind_addr, this->stop_verify_retries_);
       while (!this->commands_to_send_.empty())
         this->commands_to_send_.pop();
-      for (uint8_t i = 0; i < ELERO_STOP_REPEAT_COUNT; i++)
-        this->commands_to_send_.push(this->command_stop_);
+      this->command_.payload[4] = this->command_stop_;
+      this->parent_->send_command_priority(&this->command_);
+      this->increase_counter();
       this->stop_verify_at_ = millis() + ELERO_STOP_VERIFY_DELAY_MS;
       op = COVER_OPERATION_IDLE;  // keep our side idle while retrying
     } else {
-      // Motor confirmed stopped — clear verification state
+      // Motor confirmed stopped — correct position for actual stop delay
+      if (this->stop_trigger_ms_ > 0 && this->open_duration_ > 0 && this->close_duration_ > 0) {
+        uint32_t actual_delay = millis() - this->stop_trigger_ms_;
+        float correction_dur = (this->last_operation_ == COVER_OPERATION_OPENING)
+                                ? static_cast<float>(this->open_duration_)
+                                : static_cast<float>(this->close_duration_);
+        float overshoot = static_cast<float>(actual_delay) / correction_dur;
+        if (this->last_operation_ == COVER_OPERATION_OPENING)
+          pos = clamp(this->stop_trigger_position_ + overshoot, 0.0f, 1.0f);
+        else
+          pos = clamp(this->stop_trigger_position_ - overshoot, 0.0f, 1.0f);
+        ESP_LOGD(TAG, "Blind 0x%06x stop verified: corrected pos %.2f -> %.2f (delay %ums)",
+                 this->command_.blind_addr, this->stop_trigger_position_, pos, actual_delay);
+      }
+      this->stop_trigger_ms_ = 0;
+      // Clear stop_urgent so other covers can resume normal dispatch
+      this->parent_->set_stop_urgent(false);
       this->stop_verify_retries_ = ELERO_STOP_VERIFY_MAX_RETRIES;
       this->stop_verify_at_ = 0;
     }
@@ -346,6 +377,8 @@ void EleroCover::start_movement(CoverOperation dir) {
   // Cancel any pending stop verification — a new movement command supersedes it
   this->stop_verify_at_ = 0;
   this->stop_verify_retries_ = ELERO_STOP_VERIFY_MAX_RETRIES;
+  this->stop_trigger_ms_ = 0;
+  this->parent_->set_stop_urgent(false);
 
   // When reversing direction while moving, clear the queue so the old
   // direction command isn't sent before the new one.  Without this, a
@@ -401,9 +434,13 @@ void EleroCover::start_movement(CoverOperation dir) {
       // Clear any pending movement commands so STOP is sent immediately
       while (!this->commands_to_send_.empty())
         this->commands_to_send_.pop();
-      // Send stop multiple times for RF reliability (mirrors auto-stop behavior)
-      for (uint8_t i = 0; i < ELERO_STOP_REPEAT_COUNT; i++)
-        this->commands_to_send_.push(this->command_stop_);
+      // Send stop via priority queue for immediate processing
+      this->parent_->set_stop_urgent(true);
+      this->stop_trigger_position_ = this->position;
+      this->stop_trigger_ms_ = millis();
+      this->command_.payload[4] = this->command_stop_;
+      this->parent_->send_command_priority(&this->command_);
+      this->increase_counter();
       // Schedule verification to confirm motor actually stopped
       this->stop_verify_at_ = millis() + ELERO_STOP_VERIFY_DELAY_MS;
       this->stop_verify_retries_ = 0;

--- a/components/elero/cover/EleroCover.h
+++ b/components/elero/cover/EleroCover.h
@@ -129,6 +129,8 @@ class EleroCover : public cover::Cover, public Component, public EleroBlindBase 
   uint8_t  stop_verify_retries_{ELERO_STOP_VERIFY_MAX_RETRIES};  // verification counter (MAX = inactive)
   uint32_t last_immediate_poll_ms_{0};  // rate-limit schedule_immediate_poll()
   bool queue_full_published_{false};    // true when "queue_full" has been published to text sensor
+  float    stop_trigger_position_{0};   // position when auto-stop was triggered (for correction)
+  uint32_t stop_trigger_ms_{0};         // millis() when auto-stop was triggered
 };
 
 } // namespace elero

--- a/components/elero/elero.cpp
+++ b/components/elero/elero.cpp
@@ -174,6 +174,15 @@ void dispatch_commands(Elero *parent, std::queue<uint8_t> &queue,
   if (parent->is_failed()) return;
   if (!parent->is_tx_idle()) return;
 
+  // When stop_urgent is active, defer non-stop commands from other covers
+  // so the stopping cover's packets transmit without queue contention.
+  if (parent->is_stop_urgent() && !queue.empty()) {
+    uint8_t front_cmd = queue.front();
+    if (front_cmd != ELERO_COMMAND_COVER_STOP) {
+      return;  // defer until stop_urgent clears
+    }
+  }
+
   // Exponential backoff on retries: normal delay is send_delay (1ms),
   // but after failures we wait 10/20/40ms to break the thundering herd
   // when multiple covers retry simultaneously.
@@ -244,6 +253,7 @@ Elero::~Elero() {
   this->radio_module_ = nullptr;
   // 3. Clean up FreeRTOS resources
   if (this->tx_queue_) { vQueueDelete(this->tx_queue_); this->tx_queue_ = nullptr; }
+  if (this->tx_priority_queue_) { vQueueDelete(this->tx_priority_queue_); this->tx_priority_queue_ = nullptr; }
   if (this->rx_queue_) { vQueueDelete(this->rx_queue_); this->rx_queue_ = nullptr; }
 #ifdef USE_LOGGER
   // Callback-based log listener — no heap allocation to clean up.
@@ -711,7 +721,16 @@ void Elero::radio_task_func_(void *param) {
   ESP_LOGI(TAG, "Radio task started on Core %d", xPortGetCoreID());
   while (!hub->task_shutdown_.load(std::memory_order_acquire)) {
     hub->radio_task_loop_();
-    vTaskDelay(1);  // yield to WiFi/system tasks (~1ms)
+    // Adaptive delay: yield immediately when TX active or queues have pending work
+    // to minimize stop command latency; sleep 1ms when idle to save CPU.
+    bool has_work = (hub->tx_state_.load(std::memory_order_acquire) != TxState::IDLE) ||
+                    (hub->tx_priority_queue_ && uxQueueMessagesWaiting(hub->tx_priority_queue_) > 0) ||
+                    (hub->tx_queue_ && uxQueueMessagesWaiting(hub->tx_queue_) > 0);
+    if (has_work) {
+      taskYIELD();
+    } else {
+      vTaskDelay(1);  // yield to WiFi/system tasks (~1ms)
+    }
   }
   ESP_LOGI(TAG, "Radio task shutting down");
   hub->radio_task_handle_ = nullptr;  // signal destructor we're done
@@ -719,9 +738,15 @@ void Elero::radio_task_func_(void *param) {
 }
 
 void Elero::radio_task_loop_() {
-  // 1. Process TX commands from Core 1
+  // 1. Process TX commands from Core 1 — priority queue first for time-critical stop commands
   RadioMessage msg{};
-  if (this->tx_queue_ && xQueueReceive(this->tx_queue_, &msg, 0) == pdTRUE) {
+  bool got_msg = false;
+  if (this->tx_priority_queue_ && xQueueReceive(this->tx_priority_queue_, &msg, 0) == pdTRUE) {
+    got_msg = true;
+  } else if (this->tx_queue_ && xQueueReceive(this->tx_queue_, &msg, 0) == pdTRUE) {
+    got_msg = true;
+  }
+  if (got_msg) {
     switch (msg.type) {
       case RadioControlType::TX_COMMAND:
         this->send_command_internal_(&msg.tx.cmd);
@@ -884,8 +909,9 @@ void Elero::setup() {
 
   // Create FreeRTOS queues for dual-core communication
   this->tx_queue_ = xQueueCreate(16, sizeof(RadioMessage));
+  this->tx_priority_queue_ = xQueueCreate(4, sizeof(RadioMessage));  // small priority queue for stop commands
   this->rx_queue_ = xQueueCreate(32, sizeof(RxResult));  // 32 deep for 5+ simultaneous blind responses
-  if (!this->tx_queue_ || !this->rx_queue_) {
+  if (!this->tx_queue_ || !this->tx_priority_queue_ || !this->rx_queue_) {
     ESP_LOGE(TAG, "Failed to create FreeRTOS queues for radio task");
     this->mark_failed(LOG_STR("Failed to allocate radio task queues"));
     return;
@@ -1622,6 +1648,26 @@ bool Elero::send_command(t_elero_command *cmd) {
     return true;
   }
   ESP_LOGW(TAG, "TX queue full, command to 0x%06x dropped", cmd->blind_addr);
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// send_command_priority — public API (Core 1): enqueue a high-priority TX
+// command (e.g. stop) that bypasses the normal queue.
+// ---------------------------------------------------------------------------
+bool Elero::send_command_priority(t_elero_command *cmd) {
+  if (this->spi_failed_.load(std::memory_order_acquire))
+    return false;
+  if (!this->tx_priority_queue_)
+    return false;
+
+  RadioMessage msg{};
+  msg.type = RadioControlType::TX_COMMAND;
+  msg.tx.cmd = *cmd;
+  if (xQueueSend(this->tx_priority_queue_, &msg, pdMS_TO_TICKS(10)) == pdTRUE) {
+    return true;
+  }
+  ESP_LOGW(TAG, "Priority TX queue full, command to 0x%06x dropped", cmd->blind_addr);
   return false;
 }
 

--- a/components/elero/elero.h
+++ b/components/elero/elero.h
@@ -402,6 +402,15 @@ class Elero : public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARIT
   void register_cover(EleroBlindBase *cover);
   void register_light(EleroLightBase *light);
   bool send_command(t_elero_command *cmd);
+  /// Priority TX: bypasses the normal queue for time-critical commands (e.g. stop).
+  bool send_command_priority(t_elero_command *cmd);
+  /// Current number of messages waiting in the normal TX queue (for dynamic latency compensation).
+  uint32_t get_tx_queue_depth() const {
+    return tx_queue_ ? uxQueueMessagesWaiting(tx_queue_) : 0;
+  }
+  /// Signal that a stop command is urgent — other covers should defer non-stop TX.
+  void set_stop_urgent(bool urgent) { stop_urgent_.store(urgent, std::memory_order_release); }
+  bool is_stop_urgent() const { return stop_urgent_.load(std::memory_order_acquire); }
 
 #ifdef USE_SENSOR
   void register_rssi_sensor(uint32_t address, sensor::Sensor *sensor);
@@ -637,8 +646,10 @@ class Elero : public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARIT
 
   // Radio task (Core 0) — handles ALL SPI communication after setup()
   TaskHandle_t radio_task_handle_{nullptr};
-  QueueHandle_t tx_queue_{nullptr};   // Core 1 → Core 0: RadioMessage (TX commands, control)
-  QueueHandle_t rx_queue_{nullptr};   // Core 0 → Core 1: RxResult (decoded packets)
+  QueueHandle_t tx_queue_{nullptr};           // Core 1 → Core 0: RadioMessage (TX commands, control)
+  QueueHandle_t tx_priority_queue_{nullptr};  // Core 1 → Core 0: high-priority TX (stop commands)
+  QueueHandle_t rx_queue_{nullptr};           // Core 0 → Core 1: RxResult (decoded packets)
+  std::atomic<bool> stop_urgent_{false};      // true when a cover is sending urgent stop commands
   std::atomic<bool> task_shutdown_{false};       // Core 1 sets to signal radio task to exit
   std::atomic<bool> radio_fatal_error_{false};   // Core 0 sets when SPI permanently fails
 };


### PR DESCRIPTION
Add SPI diagnostic logging on CC1101 init failure

When SPI health check fails, read the CC1101 PARTNUM and VERSION status
registers (expected 0x00/0x14) and test writes with multiple byte patterns.
This helps distinguish between:
- Chip detected but writes fail (MOSI issue or bus conflict)
- All zeros (MISO stuck LOW or CS issue)
- All ones (MISO stuck HIGH or chip not powered)
- Unexpected chip ID (wrong SPI bus or not a CC1101)

https://claude.ai/code/session_01M3MVgj94zq9RtVeNmerg2C