### PR TITLE
Merge pull request #116 from pfriedrich84/claude/fix-radiolib-compilation-ZtVd9

### DIFF
--- a/compile_test.yaml
+++ b/compile_test.yaml
@@ -128,26 +128,9 @@ sensor:
     update_interval: 30s
     icon: "mdi:stack-overflow"
 
-  # CC1101 current frequency in MHz (reflects runtime changes via web API)
-  - platform: template
-    name: "Current Frequency"
-    lambda: |-
-      auto *hub = id(elero_hub);
-      return esphome::elero::Elero::registers_to_mhz(
-        hub->get_freq2(), hub->get_freq1(), hub->get_freq0());
-    unit_of_measurement: "MHz"
-    accuracy_decimals: 2
-    update_interval: 60s
-    icon: "mdi:sine-wave"
-
-  # Radio watchdog recovery count (non-zero = CC1101 had problems)
-  - platform: template
-    name: "Watchdog Recovery Count"
-    lambda: |-
-      return (float)id(elero_hub)->get_watchdog_recovery_count();
-    accuracy_decimals: 0
-    update_interval: 30s
-    icon: "mdi:alert-circle-outline"
+  # NOTE: Frequency, RX Count, TX Count, and Watchdog Recovery Count sensors
+  # are now auto-created by the elero hub (auto_sensors: true, the default).
+  # To disable: add "auto_sensors: false" to the elero: hub config.
 
   # Core 0 idle percentage (radio task core)
   # Uses ESP-IDF runtime stats — requires CONFIG_FREERTOS_GENERATE_RUN_TIME_STATS

--- a/components/elero/__init__.py
+++ b/components/elero/__init__.py
@@ -3,13 +3,18 @@ import logging
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome import pins
-from esphome.components import spi
-from esphome.const import CONF_ID
+from esphome.components import spi, sensor
+from esphome.const import (
+    CONF_ID,
+    STATE_CLASS_MEASUREMENT,
+    STATE_CLASS_TOTAL_INCREASING,
+)
 from esphome.core import CORE
 
 _LOGGER = logging.getLogger(__name__)
 
 DEPENDENCIES = ["spi"]
+AUTO_LOAD = ["sensor"]
 
 # ESP32 strapping pins that can cause boot issues when used for SPI or I/O.
 # GPIO12 (MTDI) is especially problematic on original ESP32: if pulled HIGH at
@@ -30,8 +35,61 @@ CONF_FREQ1 = "freq1"
 CONF_FREQ2 = "freq2"
 CONF_SEND_REPEATS = "send_repeats"
 CONF_SEND_DELAY = "send_delay"
+CONF_AUTO_SENSORS = "auto_sensors"
+CONF_FREQUENCY_SENSOR = "frequency_sensor"
+CONF_RX_COUNT_SENSOR = "rx_count_sensor"
+CONF_TX_COUNT_SENSOR = "tx_count_sensor"
+CONF_WATCHDOG_RECOVERY_SENSOR = "watchdog_recovery_sensor"
 
-CONFIG_SCHEMA = (
+_FREQUENCY_SENSOR_SCHEMA = sensor.sensor_schema(
+    unit_of_measurement="MHz",
+    accuracy_decimals=2,
+    state_class=STATE_CLASS_MEASUREMENT,
+    icon="mdi:sine-wave",
+)
+_RX_COUNT_SENSOR_SCHEMA = sensor.sensor_schema(
+    accuracy_decimals=0,
+    state_class=STATE_CLASS_TOTAL_INCREASING,
+    icon="mdi:counter",
+)
+_TX_COUNT_SENSOR_SCHEMA = sensor.sensor_schema(
+    accuracy_decimals=0,
+    state_class=STATE_CLASS_TOTAL_INCREASING,
+    icon="mdi:counter",
+)
+_WATCHDOG_RECOVERY_SENSOR_SCHEMA = sensor.sensor_schema(
+    accuracy_decimals=0,
+    state_class=STATE_CLASS_TOTAL_INCREASING,
+    icon="mdi:alert-circle-outline",
+)
+
+
+def _auto_sensor_validator(config):
+    """At validation time, inject hub-level diagnostic sensor configs when auto_sensors=True."""
+    if not config.get(CONF_AUTO_SENSORS, True):
+        return config
+    result = dict(config)
+    prefix = "Elero"
+    if CONF_FREQUENCY_SENSOR not in result:
+        result[CONF_FREQUENCY_SENSOR] = _FREQUENCY_SENSOR_SCHEMA(
+            {"name": f"{prefix} Frequency"}
+        )
+    if CONF_RX_COUNT_SENSOR not in result:
+        result[CONF_RX_COUNT_SENSOR] = _RX_COUNT_SENSOR_SCHEMA(
+            {"name": f"{prefix} RX Count"}
+        )
+    if CONF_TX_COUNT_SENSOR not in result:
+        result[CONF_TX_COUNT_SENSOR] = _TX_COUNT_SENSOR_SCHEMA(
+            {"name": f"{prefix} TX Count"}
+        )
+    if CONF_WATCHDOG_RECOVERY_SENSOR not in result:
+        result[CONF_WATCHDOG_RECOVERY_SENSOR] = _WATCHDOG_RECOVERY_SENSOR_SCHEMA(
+            {"name": f"{prefix} Watchdog Recovery Count"}
+        )
+    return result
+
+
+CONFIG_SCHEMA = cv.All(
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(elero),
@@ -41,10 +99,16 @@ CONFIG_SCHEMA = (
             cv.Optional(CONF_FREQ2, default=0x21): cv.hex_int_range(min=0x0, max=0xff),
             cv.Optional(CONF_SEND_REPEATS, default=1): cv.int_range(min=1, max=20),
             cv.Optional(CONF_SEND_DELAY, default="1ms"): cv.positive_time_period_milliseconds,
+            cv.Optional(CONF_AUTO_SENSORS, default=True): cv.boolean,
+            cv.Optional(CONF_FREQUENCY_SENSOR): _FREQUENCY_SENSOR_SCHEMA,
+            cv.Optional(CONF_RX_COUNT_SENSOR): _RX_COUNT_SENSOR_SCHEMA,
+            cv.Optional(CONF_TX_COUNT_SENSOR): _TX_COUNT_SENSOR_SCHEMA,
+            cv.Optional(CONF_WATCHDOG_RECOVERY_SENSOR): _WATCHDOG_RECOVERY_SENSOR_SCHEMA,
         }
     )
     .extend(cv.COMPONENT_SCHEMA)
-    .extend(spi.spi_device_schema(cs_pin_required=True))
+    .extend(spi.spi_device_schema(cs_pin_required=True)),
+    _auto_sensor_validator,
 )
 
 
@@ -105,6 +169,20 @@ async def to_code(config):
     cg.add(var.set_freq2(config[CONF_FREQ2]))
     cg.add(var.set_send_repeats(config[CONF_SEND_REPEATS]))
     cg.add(var.set_send_delay(config[CONF_SEND_DELAY].total_milliseconds))
+
+    # Hub-level diagnostic sensors (auto_sensors or explicitly configured)
+    if CONF_FREQUENCY_SENSOR in config:
+        freq_sens = await sensor.new_sensor(config[CONF_FREQUENCY_SENSOR])
+        cg.add(var.set_frequency_sensor(freq_sens))
+    if CONF_RX_COUNT_SENSOR in config:
+        rx_sens = await sensor.new_sensor(config[CONF_RX_COUNT_SENSOR])
+        cg.add(var.set_rx_count_sensor(rx_sens))
+    if CONF_TX_COUNT_SENSOR in config:
+        tx_sens = await sensor.new_sensor(config[CONF_TX_COUNT_SENSOR])
+        cg.add(var.set_tx_count_sensor(tx_sens))
+    if CONF_WATCHDOG_RECOVERY_SENSOR in config:
+        wd_sens = await sensor.new_sensor(config[CONF_WATCHDOG_RECOVERY_SENSOR])
+        cg.add(var.set_watchdog_recovery_sensor(wd_sens))
 
     # Add RadioLib as PlatformIO library dependency.
     # RadioLib's Module.h includes <SPI.h> when RADIOLIB_BUILD_ARDUINO is defined

--- a/components/elero/elero.cpp
+++ b/components/elero/elero.cpp
@@ -295,6 +295,25 @@ void Elero::loop() {
 
   // 3. Recompute dead-reckoning positions for runtime-adopted blinds.
   this->recompute_runtime_positions_();
+
+  // 4. Publish hub-level diagnostic sensors periodically (every 30 s).
+#ifdef USE_SENSOR
+  {
+    uint32_t now = millis();
+    if (now - this->last_hub_sensor_update_ms_ >= 30000) {
+      this->last_hub_sensor_update_ms_ = now;
+      if (this->frequency_sensor_ != nullptr)
+        this->frequency_sensor_->publish_state(
+            registers_to_mhz(this->freq2_, this->freq1_, this->freq0_));
+      if (this->rx_count_sensor_ != nullptr)
+        this->rx_count_sensor_->publish_state((float) this->get_rx_count());
+      if (this->tx_count_sensor_ != nullptr)
+        this->tx_count_sensor_->publish_state((float) this->get_tx_count());
+      if (this->watchdog_recovery_sensor_ != nullptr)
+        this->watchdog_recovery_sensor_->publish_state((float) this->get_watchdog_recovery_count());
+    }
+  }
+#endif
 }
 
 // ---------------------------------------------------------------------------
@@ -951,6 +970,20 @@ void Elero::setup() {
   // With dual-core, this speeds up RX queue draining on Core 1 and improves
   // position tracking responsiveness for auto-stop.
   this->high_freq_.start();
+
+  // Publish initial values for hub-level diagnostic sensors.
+#ifdef USE_SENSOR
+  if (this->frequency_sensor_ != nullptr)
+    this->frequency_sensor_->publish_state(
+        registers_to_mhz(this->freq2_, this->freq1_, this->freq0_));
+  if (this->rx_count_sensor_ != nullptr)
+    this->rx_count_sensor_->publish_state(0.0f);
+  if (this->tx_count_sensor_ != nullptr)
+    this->tx_count_sensor_->publish_state(0.0f);
+  if (this->watchdog_recovery_sensor_ != nullptr)
+    this->watchdog_recovery_sensor_->publish_state(0.0f);
+  this->last_hub_sensor_update_ms_ = millis();
+#endif
 }
 
 float Elero::registers_to_mhz(uint8_t freq2, uint8_t freq1, uint8_t freq0) {

--- a/components/elero/elero.h
+++ b/components/elero/elero.h
@@ -423,6 +423,11 @@ class Elero : public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARIT
 
 #ifdef USE_SENSOR
   void register_rssi_sensor(uint32_t address, sensor::Sensor *sensor);
+  // Hub-level diagnostic sensors
+  void set_frequency_sensor(sensor::Sensor *sensor) { frequency_sensor_ = sensor; }
+  void set_rx_count_sensor(sensor::Sensor *sensor) { rx_count_sensor_ = sensor; }
+  void set_tx_count_sensor(sensor::Sensor *sensor) { tx_count_sensor_ = sensor; }
+  void set_watchdog_recovery_sensor(sensor::Sensor *sensor) { watchdog_recovery_sensor_ = sensor; }
 #endif
 #ifdef USE_TEXT_SENSOR
   void register_text_sensor(uint32_t address, text_sensor::TextSensor *sensor);
@@ -603,6 +608,12 @@ class Elero : public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARIT
   std::map<uint32_t, EleroLightBase*> address_to_light_mapping_;
 #ifdef USE_SENSOR
   std::map<uint32_t, sensor::Sensor*> address_to_rssi_sensor_;
+  // Hub-level diagnostic sensors (nullptr if not configured)
+  sensor::Sensor *frequency_sensor_{nullptr};
+  sensor::Sensor *rx_count_sensor_{nullptr};
+  sensor::Sensor *tx_count_sensor_{nullptr};
+  sensor::Sensor *watchdog_recovery_sensor_{nullptr};
+  uint32_t last_hub_sensor_update_ms_{0};
 #endif
 #ifdef USE_TEXT_SENSOR
   std::map<uint32_t, text_sensor::TextSensor*> address_to_text_sensor_;


### PR DESCRIPTION
Add SPI diagnostic logging on CC1101 init failure

When SPI health check fails, read the CC1101 PARTNUM and VERSION status
registers (expected 0x00/0x14) and test writes with multiple byte patterns.
This helps distinguish between:
- Chip detected but writes fail (MOSI issue or bus conflict)
- All zeros (MISO stuck LOW or CS issue)
- All ones (MISO stuck HIGH or chip not powered)
- Unexpected chip ID (wrong SPI bus or not a CC1101)

https://claude.ai/code/session_01M3MVgj94zq9RtVeNmerg2C