### PR TITLE
fix(build): eliminate ~38 compile warnings

### DIFF
--- a/components/elero/__init__.py
+++ b/components/elero/__init__.py
@@ -202,7 +202,7 @@ async def to_code(config):
         "RADIOLIB_EXCLUDE_RFM2X",
         "RADIOLIB_EXCLUDE_SX127X",
         "RADIOLIB_EXCLUDE_SX126X",
-        "RADIOLIB_EXCLUDE_STM32WLX",
+        # STM32WLX is NOT listed here — RadioLib auto-excludes it on non-STM32 platforms
         "RADIOLIB_EXCLUDE_SX128X",
         "RADIOLIB_EXCLUDE_LR11X0",
         # Protocol decoders (none used by this project)

--- a/components/elero_web/elero_web_server.cpp
+++ b/components/elero_web/elero_web_server.cpp
@@ -3,6 +3,7 @@
 #include "elero_web_utils.h"
 #include "esphome/core/log.h"
 #include "esphome/core/application.h"
+#include "esphome/core/version.h"
 #include <cstdio>
 #include <cstring>
 #include <cstdlib>
@@ -102,12 +103,22 @@ void EleroWebServer::dump_config() {
 
 bool EleroWebServer::canHandle(AsyncWebServerRequest *request) const {
   if (!this->enabled_.load(std::memory_order_acquire)) return false;
-  const std::string &url = request->url();
+#if ESPHOME_VERSION_CODE >= VERSION_CODE(2026, 3, 0)
+  char url_buf[AsyncWebServerRequest::URL_BUF_SIZE];
+  const std::string url(request->url_to(url_buf));
+#else
+  const std::string url = request->url();
+#endif
   return url == "/" || (url.size() >= 6 && url.compare(0, 6, "/elero") == 0);
 }
 
 void EleroWebServer::handleRequest(AsyncWebServerRequest *request) {
+#if ESPHOME_VERSION_CODE >= VERSION_CODE(2026, 3, 0)
+  char url_buf[AsyncWebServerRequest::URL_BUF_SIZE];
+  const std::string url(request->url_to(url_buf));
+#else
   const std::string url = request->url();
+#endif
   const auto method = request->method();
 
   if (method == HTTP_OPTIONS) { handle_options(request); return; }


### PR DESCRIPTION
## Summary
- Remove `RADIOLIB_EXCLUDE_STM32WLX` from build flags — RadioLib v7.1.2 auto-excludes it on non-STM32 platforms, eliminating ~36 redefinition warnings per build
- Migrate `request->url()` to `url_to()` in `elero_web_server.cpp` with version guard for ESPHome <2026.3.0 backward compatibility (2 deprecation warnings)

Closes #150

## Test plan
- [ ] Compile with `esphome compile` and verify zero `RADIOLIB_EXCLUDE_STM32WLX` warnings
- [ ] Verify zero `url() deprecated` warnings on ESP-IDF builds
- [ ] `ruff check components/` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)