### PR TITLE
Fix dedup default: disable unless configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ elero:
   freq2: 0x21            # Optional: Frequenz-Register FREQ2 (Standard: 0x21)
   send_repeats: 1        # Optional: RF-Pakete pro Befehl (1-20, Standard: 1 = keine Wiederholung)
   send_delay: 0ms        # Optional: Pause zwischen Wiederholungen (Standard: 0ms)
-  dedup_window: 500ms    # Optional: Duplikat-Unterdrückung für Statuspakete
+  dedup_window: 0ms      # Optional: 0ms=aus (Default), sonst z.B. 500ms für Duplikat-Unterdrückung
 ```
 
 | Parameter | Typ | Pflicht | Standard | Beschreibung |
@@ -192,7 +192,7 @@ elero:
 | `freq2` | Hex (0x00-0xFF) | Nein | `0x21` | CC1101 FREQ2 Register |
 | `send_repeats` | Int (1-20) | Nein | `1` | RF-Pakete pro Befehl; `1` bedeutet keine Wiederholung |
 | `send_delay` | Zeitdauer | Nein | `0ms` | Pause zwischen Wiederholungen |
-| `dedup_window` | Zeitdauer | Nein | `500ms` | Statuspaket-Duplikate gleicher Quelle/Zähler unterdrücken; bei Doppelstatus auf `1s`-`2s` erhöhen |
+| `dedup_window` | Zeitdauer | Nein | `0ms` | `0ms` deaktiviert Deduplication (Default); zum Unterdrücken von Statuspaket-Duplikaten gleicher Quelle/Zähler z.B. `500ms` setzen |
 | `auto_sensors` | Boolean | Nein | `true` | Hub-Diagnose-Sensoren automatisch erstellen |
 
 ### Plattform `cover` (Rollladen)

--- a/components/elero/__init__.py
+++ b/components/elero/__init__.py
@@ -85,8 +85,8 @@ _LATENCY_SENSOR_SCHEMA = esphome_sensor.sensor_schema(
 def _validate_dedup_window(config):
     """Keep dedup tuning within safe operational bounds."""
     window_ms = config[CONF_DEDUP_WINDOW].total_milliseconds
-    if window_ms < 100 or window_ms > 60000:
-        raise cv.Invalid("dedup_window must be between 100ms and 60s")
+    if window_ms != 0 and (window_ms < 100 or window_ms > 60000):
+        raise cv.Invalid("dedup_window must be 0ms (disabled) or between 100ms and 60s")
     return config
 
 
@@ -131,7 +131,7 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_FREQ2, default=0x21): cv.hex_int_range(min=0x0, max=0xFF),
             cv.Optional(CONF_SEND_REPEATS, default=1): cv.int_range(min=1, max=20),
             cv.Optional(CONF_SEND_DELAY, default="0ms"): cv.positive_time_period_milliseconds,
-            cv.Optional(CONF_DEDUP_WINDOW, default="500ms"): cv.positive_time_period_milliseconds,
+            cv.Optional(CONF_DEDUP_WINDOW, default="0ms"): cv.positive_time_period_milliseconds,
             cv.Optional(CONF_AUTO_SENSORS, default=True): cv.boolean,
             cv.Optional(CONF_FREQUENCY_SENSOR): _FREQUENCY_SENSOR_SCHEMA,
             cv.Optional(CONF_RX_COUNT_SENSOR): _RX_COUNT_SENSOR_SCHEMA,

--- a/components/elero/elero.h
+++ b/components/elero/elero.h
@@ -61,8 +61,8 @@ enum class SendResult : uint8_t {
 static const uint32_t ELERO_IMMEDIATE_POLL_MIN_INTERVAL_MS = 2000;
 
 /// Deduplication: default time window in ms within which (src, cnt) duplicates are suppressed.
-/// 500 ms catches immediate relay/FIFO duplicates without hiding later legitimate status updates.
-static const uint32_t ELERO_DEDUP_WINDOW_MS = 500;
+/// 0 ms disables dedup by default; set dedup_window explicitly to opt in.
+static const uint32_t ELERO_DEDUP_WINDOW_MS = 0;
 
 }  // namespace elero
 

--- a/components/elero/elero_cc1101.cpp
+++ b/components/elero/elero_cc1101.cpp
@@ -233,6 +233,8 @@ void Elero::tx_abort_() {
 // is_duplicate_packet_ — suppress relay-hop duplicates of the same packet
 // ---------------------------------------------------------------------------
 bool Elero::is_duplicate_packet_(uint32_t src, uint8_t cnt) {
+  if (this->dedup_window_ms_ == 0)
+    return false;
   uint32_t now = millis();
   uint64_t key = (static_cast<uint64_t>(src) << 8) | cnt;
   auto it = this->dedup_map_.find(key);
@@ -245,6 +247,10 @@ bool Elero::is_duplicate_packet_(uint32_t src, uint8_t cnt) {
 }
 
 void Elero::prune_dedup_map_() {
+  if (this->dedup_window_ms_ == 0) {
+    this->dedup_map_.clear();
+    return;
+  }
   uint32_t now = millis();
   if (now - this->last_dedup_prune_ms_ < RADIO_WATCHDOG_MS)
     return;

--- a/docs/developer/development.md
+++ b/docs/developer/development.md
@@ -320,7 +320,7 @@ Key constants (defined in `elero.h` unless noted):
 | `ELERO_MAX_RX_PER_LOOP` | 8 | Max packets drained per `dispatch_rx_result_()` cycle |
 | `ELERO_POLL_STAGGER_MS` | 5 000 ms | Stagger offset between cover poll timers |
 | `ELERO_IMMEDIATE_POLL_MIN_INTERVAL_MS` | 2 000 ms | Minimum interval between `schedule_immediate_poll()` calls per blind |
-| `ELERO_DEDUP_WINDOW_MS` | 500 ms | Default packet deduplication time window (src, cnt pairs), configurable via `dedup_window` |
+| `ELERO_DEDUP_WINDOW_MS` | 0 ms | Default packet deduplication window disabled (opt-in via `dedup_window`; src, cnt pairs) |
 | `ELERO_STOP_REPEAT_COUNT` | 2 | Stop commands queued on auto-stop (x2 RF packets each) |
 | `ELERO_TX_LATENCY_COMPENSATION_MS` | 300 ms | Position check lead time (accounts for multi-cover queue contention) |
 | `ELERO_STOP_VERIFY_DELAY_MS` | 2 000 ms | Delay before polling to verify motor stopped (give blind time to broadcast) |

--- a/docs/user/configuration.md
+++ b/docs/user/configuration.md
@@ -26,7 +26,7 @@ elero:
 | `freq2` | Hex (0x00-0xFF) | Nein | `0x21` | CC1101 Frequenz-Register FREQ2 |
 | `send_repeats` | Integer (1-20) | Nein | `1` | Anzahl der RF-Pakete pro Befehl; `1` bedeutet keine Wiederholung |
 | `send_delay` | Zeitdauer | Nein | `0ms` | Verzögerung zwischen wiederholten Paketen |
-| `dedup_window` | Zeitdauer (`100ms`-`60s`) | Nein | `500ms` | Zeitfenster, in dem doppelte Statuspakete gleicher Quelle/Zähler unterdrückt werden. Bei sichtbaren Doppelstatus ggf. auf `1s`-`2s` erhöhen. |
+| `dedup_window` | Zeitdauer (`0ms` oder `100ms`-`60s`) | Nein | `0ms` | Zeitfenster, in dem doppelte Statuspakete gleicher Quelle/Zähler unterdrückt werden. `0ms` deaktiviert Deduplication (Default); zum Aktivieren z.B. `500ms` setzen. |
 | `auto_sensors` | Boolean | Nein | `true` | Erstellt automatisch Hub-Diagnose-Sensoren (Frequenz, Zähler, Drop- und Latenzmetriken) |
 
 > Der Hub erweitert die ESPHome SPI-Konfiguration. `spi:` muss separat mit `clk_pin`, `mosi_pin` und `miso_pin` konfiguriert sein.

--- a/tests/python/test_hub_dedup_window.py
+++ b/tests/python/test_hub_dedup_window.py
@@ -1,0 +1,31 @@
+"""Tests for hub dedup_window validation semantics."""
+
+import pytest
+from conftest import make_time_period
+from esphome.config_validation import Invalid
+
+from components.elero import CONF_DEDUP_WINDOW, _validate_dedup_window
+
+
+def _config(window_ms):
+    return {CONF_DEDUP_WINDOW: make_time_period(window_ms)}
+
+
+def test_dedup_window_disabled_zero_allowed():
+    result = _validate_dedup_window(_config(0))
+    assert result is not None
+
+
+def test_dedup_window_opt_in_lower_bound_allowed():
+    result = _validate_dedup_window(_config(100))
+    assert result is not None
+
+
+def test_dedup_window_rejects_nonzero_below_lower_bound():
+    with pytest.raises(Invalid, match=r"0ms \(disabled\) or between 100ms and 60s"):
+        _validate_dedup_window(_config(99))
+
+
+def test_dedup_window_rejects_above_upper_bound():
+    with pytest.raises(Invalid, match=r"0ms \(disabled\) or between 100ms and 60s"):
+        _validate_dedup_window(_config(60001))

--- a/tests/unit/test_packet_replay.cpp
+++ b/tests/unit/test_packet_replay.cpp
@@ -101,6 +101,11 @@ TEST(PacketReplay, DedupWindowSuppressesRelayDuplicate) {
   EXPECT_TRUE(dedup_logic::should_prune_entry(1500, 1000, 500));
 }
 
+TEST(PacketReplay, DedupDisabledWindowNeverSuppressesAndAlwaysPrunes) {
+  EXPECT_FALSE(dedup_logic::is_duplicate_within_window(1200, 1000, 0));
+  EXPECT_TRUE(dedup_logic::should_prune_entry(1200, 1000, 0));
+}
+
 TEST(PacketReplay, CounterLogicRejectsStaleValuesAndAllowsWrapForward) {
   EXPECT_FALSE(counter_logic::is_stale_counter(7, 8));
   EXPECT_TRUE(counter_logic::is_stale_counter(8, 8));


### PR DESCRIPTION
## Summary
- change dedup default to 0ms (disabled)
- allow config validation for 0ms or 100ms..60s
- short-circuit runtime dedup logic when disabled
- add python and C++ regression coverage
- update docs for new default/opt-in semantics

## Verification
- local checks unavailable in this runner (missing ruff, pytest, cmake)
- CI is required and must be green before merge
