### PR TITLE
ci: use Node 24 GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,15 +25,15 @@ jobs:
   markdown:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
       - run: python3 scripts/check_markdown_links.py
 
   lint:
     if: github.event_name != 'push' || !startsWith(github.ref, 'refs/heads/docs/')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6.0.2
+      - uses: actions/setup-python@v6.2.0
         with:
           python-version: "3.12"
           cache: "pip"
@@ -60,8 +60,8 @@ jobs:
           - tests/configs/custom_frequency.yaml
           - tests/configs/esp32s3-idf.yaml
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6.0.2
+      - uses: actions/setup-python@v6.2.0
         with:
           python-version: "3.12"
           cache: "pip"
@@ -73,14 +73,14 @@ jobs:
           exit ${PIPESTATUS[0]}
       - name: Upload compile log
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: compile-log-${{ strategy.job-index }}
           path: compile.log
           retention-days: 14
       - name: Create issues from compile warnings/errors
         if: always() && github.event_name == 'push'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9.0.0
         with:
           script: |
             const fs = require('fs');
@@ -151,8 +151,8 @@ jobs:
       run:
         working-directory: components/elero_web/frontend
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6.0.2
+      - uses: actions/setup-node@v6.4.0
         with:
           node-version: "22"
       - run: npm install
@@ -170,7 +170,7 @@ jobs:
             exit 1
           fi
       - name: Upload build artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: elero-web-ui
           path: components/elero_web/elero_web_ui.h
@@ -180,7 +180,7 @@ jobs:
     if: github.event_name != 'push' || !startsWith(github.ref, 'refs/heads/docs/')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
       - name: Configure CMake
         run: cmake -S tests -B tests/build -DCMAKE_BUILD_TYPE=Debug
       - name: Build
@@ -192,8 +192,8 @@ jobs:
     if: github.event_name != 'push' || !startsWith(github.ref, 'refs/heads/docs/')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6.0.2
+      - uses: actions/setup-python@v6.2.0
         with:
           python-version: "3.12"
           cache: "pip"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0   # full history for tag lookup and changelog
 


### PR DESCRIPTION
## Summary
- update first-party GitHub Actions to Node 24-compatible releases
- keep `actions/checkout` on `v6.0.2` instead of latest `v6.0.3` to respect the 3-day minimum-age dependency policy
- update CI and release workflows only

## Version evidence
- `actions/checkout@v6.0.2` — `runs.using: node24`, published 2026-01-09
- `actions/setup-python@v6.2.0` — `runs.using: node24`, published 2026-01-22
- `actions/upload-artifact@v7.0.1` — `runs.using: node24`, published 2026-04-10
- `actions/github-script@v9.0.0` — `runs.using: node24`, published 2026-04-09
- `actions/setup-node@v6.4.0` — `runs.using: node24`, published 2026-04-20

## Validation
- [x] Markdown links: `python3 scripts/check_markdown_links.py`
- [x] Whitespace: `git diff --check`
- [ ] GitHub Actions CI on PR

## Notes for reviewers
- RF/protocol safety impact: none
- YAML/API/entity behavior impact: none
- Generated files or dependency changes: CI action versions only
