### PR TITLE
deps: group Dependabot version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,25 +1,36 @@
 version: 2
+
+multi-ecosystem-groups:
+  monthly-dependencies:
+    schedule:
+      interval: "monthly"
+    labels:
+      - "dependencies"
+
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
-    schedule:
-      interval: "monthly"
+    patterns:
+      - "*"
+    multi-ecosystem-group: "monthly-dependencies"
     cooldown:
       default-days: 3
-    open-pull-requests-limit: 3
+    open-pull-requests-limit: 1
 
   - package-ecosystem: "npm"
     directory: "/components/elero_web/frontend"
-    schedule:
-      interval: "monthly"
+    patterns:
+      - "*"
+    multi-ecosystem-group: "monthly-dependencies"
     cooldown:
       default-days: 3
-    open-pull-requests-limit: 3
+    open-pull-requests-limit: 1
 
   - package-ecosystem: "npm"
     directory: "/components/elero_web/frontend-legacy"
-    schedule:
-      interval: "monthly"
+    patterns:
+      - "*"
+    multi-ecosystem-group: "monthly-dependencies"
     cooldown:
       default-days: 3
     open-pull-requests-limit: 1

--- a/docs/agent/ASSESSMENT.md
+++ b/docs/agent/ASSESSMENT.md
@@ -43,7 +43,7 @@ Last reviewed: 2026-06-03
 - Repository is public and uses `main` as the default branch.
 - Secret scanning and push protection are enabled in GitHub repository settings.
 - Vulnerability alerts and Dependabot security updates are enabled.
-- `.github/dependabot.yml` defines monthly Dependabot version updates for GitHub Actions and npm frontend dependencies with a 3-day cooldown.
+- `.github/dependabot.yml` defines one monthly multi-ecosystem Dependabot version-update group for GitHub Actions and npm frontend dependencies with a 3-day cooldown.
 - `main` branch protection is enabled through `.github/scripts/protect-main.sh`: `ci-ok` is required, strict status checks are enabled, force pushes are blocked, and branch deletion is blocked.
 - Code scanning/CodeQL status is not established from repository files; GitHub API returned no analysis.
 - GitHub Actions are enabled and currently allow all actions; workflow files pin common first-party actions by major version.

--- a/docs/agent/SUPPLY_CHAIN.md
+++ b/docs/agent/SUPPLY_CHAIN.md
@@ -7,7 +7,7 @@ Supply-chain rules for repository changes.
 - Prefer existing dependencies and standard-library functionality over adding new packages.
 - Do not add or upgrade dependencies casually; explain the need, risk, and validation path.
 - Prefer packages/releases that have existed for at least 3 days before adoption unless the maintainer explicitly approves a newer release.
-- Dependabot version updates are configured in `.github/dependabot.yml` with a 3-day cooldown for GitHub Actions and npm ecosystems.
+- Dependabot version updates are configured in `.github/dependabot.yml` as one monthly multi-ecosystem group with a 3-day cooldown for GitHub Actions and npm ecosystems.
 - Preserve lockfiles and prefer lockfile-based installs when lockfiles are in sync. Do not introduce unrelated lockfile churn.
 - Do not commit secrets, tokens, private logs, Wi-Fi credentials, OTA/API keys, or private RF captures.
 
@@ -31,13 +31,15 @@ Use this especially for:
 
 ## Dependabot update surfaces
 
-Dependabot version updates are intentionally limited to dependency manifests that exist in this repository:
+Dependabot version updates are intentionally limited to dependency manifests that exist in this repository and are grouped into one monthly multi-ecosystem pull request:
 
 - GitHub Actions in `.github/workflows/`.
 - Active web frontend npm dependencies in `components/elero_web/frontend/`.
 - Legacy web frontend npm dependencies in `components/elero_web/frontend-legacy/`.
 
 The repository does not currently have Python dependency lockfiles or package manifests for Dependabot to maintain. CI pins Python tools directly in workflow files, so those pins are covered by the GitHub Actions ecosystem review.
+
+Keep Dependabot version-update noise low: do not split these surfaces into separate schedules or ungrouped update entries unless the maintainer explicitly accepts multiple Dependabot PRs per run.
 
 ## Optional security checks
 


### PR DESCRIPTION
## Summary
- configure Dependabot version updates as one monthly multi-ecosystem group
- group GitHub Actions, active frontend npm, and legacy frontend npm updates with `patterns: ["*"]`
- lower each configured surface to `open-pull-requests-limit: 1`
- document that Dependabot version-update noise should stay to one grouped PR per run

## Why
The first Dependabot run created separate npm PRs because the previous config had separate update entries without grouping and allowed multiple open PRs for the active frontend.

## Validation
- [x] Markdown links: `python3 scripts/check_markdown_links.py`
- [x] Whitespace: `git diff --check`
- [ ] GitHub Actions CI on PR

## Notes
Security updates have separate GitHub behavior/limits. This PR governs Dependabot version updates.
