### PR TITLE
fix(logging): correct format types for ESPHome 2026.7

### DIFF
--- a/components/elero/button/elero_button.cpp
+++ b/components/elero/button/elero_button.cpp
@@ -9,11 +9,11 @@ static const char *const TAG = "elero.button";
 void EleroScanButton::dump_config() {
   LOG_BUTTON("", "Elero Scan Button", this);
   if (this->cover_ != nullptr) {
-    ESP_LOGCONFIG(TAG, "  Action: cover_command 0x%02x -> cover 0x%06x",
-                  this->command_byte_, this->cover_->get_blind_address());
+    ESP_LOGCONFIG(TAG, "  Action: cover_command 0x%02x -> cover 0x%06lx",
+                  this->command_byte_, static_cast<unsigned long>(this->cover_->get_blind_address()));
   } else if (this->light_ != nullptr) {
-    ESP_LOGCONFIG(TAG, "  Action: light_command 0x%02x -> light 0x%06x",
-                  this->command_byte_, this->light_->get_blind_address());
+    ESP_LOGCONFIG(TAG, "  Action: light_command 0x%02x -> light 0x%06lx",
+                  this->command_byte_, static_cast<unsigned long>(this->light_->get_blind_address()));
   } else {
     ESP_LOGCONFIG(TAG, "  Action: %s", this->scan_start_ ? "start_scan" : "stop_scan");
   }
@@ -21,15 +21,15 @@ void EleroScanButton::dump_config() {
 
 void EleroScanButton::press_action() {
   if (this->cover_ != nullptr) {
-    ESP_LOGD(TAG, "Sending command 0x%02x to cover 0x%06x",
-             this->command_byte_, this->cover_->get_blind_address());
+    ESP_LOGD(TAG, "Sending command 0x%02x to cover 0x%06lx",
+             this->command_byte_, static_cast<unsigned long>(this->cover_->get_blind_address()));
     const auto mapping = this->cover_->get_command_delivery_config().mapping;
     this->cover_->submit_intent(cover_intent_for_command_byte(mapping, this->command_byte_));
     return;
   }
   if (this->light_ != nullptr) {
-    ESP_LOGD(TAG, "Sending command 0x%02x to light 0x%06x",
-             this->command_byte_, this->light_->get_blind_address());
+    ESP_LOGD(TAG, "Sending command 0x%02x to light 0x%06lx",
+             this->command_byte_, static_cast<unsigned long>(this->light_->get_blind_address()));
     const auto mapping = this->light_->get_command_delivery_config().mapping;
     this->light_->submit_intent(light_intent_for_command_byte(mapping, this->command_byte_));
     return;
@@ -44,11 +44,12 @@ void EleroScanButton::press_action() {
     this->parent_->start_scan();
   } else {
     this->parent_->stop_scan();
-    ESP_LOGI(TAG, "Stopped Elero RF scan. Discovered %d device(s).", this->parent_->get_discovered_count());
+    ESP_LOGI(TAG, "Stopped Elero RF scan. Discovered %d device(s).",
+             static_cast<int>(this->parent_->get_discovered_count()));
     for (const auto &blind : this->parent_->get_discovered_blinds()) {
-      ESP_LOGI(TAG, "  addr=0x%06x remote=0x%06x ch=%d rssi=%.1f state=%s seen=%d",
-               blind.blind_address, blind.remote_address, blind.channel,
-               blind.rssi, elero_state_to_string(blind.last_state), blind.times_seen);
+      ESP_LOGI(TAG, "  addr=0x%06lx remote=0x%06lx ch=%d rssi=%.1f state=%s seen=%d",
+               static_cast<unsigned long>(blind.blind_address), static_cast<unsigned long>(blind.remote_address),
+               blind.channel, blind.rssi, elero_state_to_string(blind.last_state), blind.times_seen);
     }
   }
 }

--- a/components/elero/cover/EleroCover.cpp
+++ b/components/elero/cover/EleroCover.cpp
@@ -13,16 +13,16 @@ static const char *const TAG = "elero.cover";
 
 void EleroCover::dump_config() {
   LOG_COVER("", "Elero Cover", this);
-  ESP_LOGCONFIG(TAG, "  Blind Address: 0x%06x", this->command_.blind_addr);
-  ESP_LOGCONFIG(TAG, "  Remote Address: 0x%06x", this->command_.remote_addr);
+  ESP_LOGCONFIG(TAG, "  Blind Address: 0x%06lx", static_cast<unsigned long>(this->command_.blind_addr));
+  ESP_LOGCONFIG(TAG, "  Remote Address: 0x%06lx", static_cast<unsigned long>(this->command_.remote_addr));
   ESP_LOGCONFIG(TAG, "  Channel: %d", this->command_.channel);
   ESP_LOGCONFIG(TAG, "  Hop: 0x%02x", this->command_.hop);
   ESP_LOGCONFIG(TAG, "  pck_inf1: 0x%02x, pck_inf2: 0x%02x", this->command_.pck_inf[0], this->command_.pck_inf[1]);
   if (this->open_duration_ > 0)
-    ESP_LOGCONFIG(TAG, "  Open Duration: %dms", this->open_duration_);
+    ESP_LOGCONFIG(TAG, "  Open Duration: %lums", static_cast<unsigned long>(this->open_duration_));
   if (this->close_duration_ > 0)
-    ESP_LOGCONFIG(TAG, "  Close Duration: %dms", this->close_duration_);
-  ESP_LOGCONFIG(TAG, "  Poll Interval: %dms", this->poll_intvl_);
+    ESP_LOGCONFIG(TAG, "  Close Duration: %lums", static_cast<unsigned long>(this->close_duration_));
+  ESP_LOGCONFIG(TAG, "  Poll Interval: %lums", static_cast<unsigned long>(this->poll_intvl_));
   ESP_LOGCONFIG(TAG, "  Supports Tilt: %s", YESNO(this->supports_tilt_));
   ESP_LOGCONFIG(TAG, "  Assumed State: %s", YESNO(this->assumed_state_));
 }
@@ -82,7 +82,8 @@ void EleroCover::loop() {
   if(this->post_movement_poll_at_ > 0 && now >= this->post_movement_poll_at_) {
     this->post_movement_poll_at_ = 0;
     if (intent_was_accepted(this->submit_intent({CommandIntentKind::CHECK, 0}))) {
-      ESP_LOGD(TAG, "Post-movement status poll for blind 0x%06x", this->command_.blind_addr);
+      ESP_LOGD(TAG, "Post-movement status poll for blind 0x%06lx",
+               static_cast<unsigned long>(this->command_.blind_addr));
       this->last_poll_ = now;
     }
   }
@@ -91,15 +92,15 @@ void EleroCover::loop() {
   if (this->stop_verify_at_ > 0 && now >= this->stop_verify_at_) {
     if (this->stop_verify_retries_ < ELERO_STOP_VERIFY_MAX_RETRIES) {
       this->stop_verify_retries_++;
-      ESP_LOGD(TAG, "Stop verify poll #%d for blind 0x%06x",
-               this->stop_verify_retries_, this->command_.blind_addr);
+      ESP_LOGD(TAG, "Stop verify poll #%d for blind 0x%06lx",
+               this->stop_verify_retries_, static_cast<unsigned long>(this->command_.blind_addr));
       this->submit_intent({CommandIntentKind::CHECK, 0});
       // Reschedule in case no RF response arrives (prevents verification stall)
       this->stop_verify_at_ = now + ELERO_STOP_VERIFY_DELAY_MS;
     } else {
       // Exhausted retries — give up verification
-      ESP_LOGW(TAG, "Stop verification exhausted %d retries for blind 0x%06x",
-               ELERO_STOP_VERIFY_MAX_RETRIES, this->command_.blind_addr);
+      ESP_LOGW(TAG, "Stop verification exhausted %d retries for blind 0x%06lx",
+               ELERO_STOP_VERIFY_MAX_RETRIES, static_cast<unsigned long>(this->command_.blind_addr));
       this->stop_verify_at_ = 0;
       this->stop_trigger_ms_ = 0;
       this->finish_stop_verification_();
@@ -131,8 +132,8 @@ void EleroCover::loop() {
       (this->open_duration_ > 0) && (this->close_duration_ > 0)) {
     this->recompute_position();
     if(this->is_at_target()) {
-      ESP_LOGI(TAG, "Blind 0x%06x reached target (pos=%.2f, target=%.2f), sending stop",
-               this->command_.blind_addr, this->position, this->target_position_);
+      ESP_LOGI(TAG, "Blind 0x%06lx reached target (pos=%.2f, target=%.2f), sending stop",
+               static_cast<unsigned long>(this->command_.blind_addr), this->position, this->target_position_);
       if (!this->pending_stop_transition_) {
         // Queueing locally is not proof that the hub accepted the priority
         // packet. Keep tracking movement until advance() reports first RF queue
@@ -208,7 +209,8 @@ void EleroCover::handle_delivery_outcome_(const DeliveryOutcome &outcome) {
   }
 
   if (outcome.event == DeliveryEvent::DROPPED) {
-    ESP_LOGE(TAG, "Delivery retries exhausted for blind 0x%06x", this->command_.blind_addr);
+    ESP_LOGE(TAG, "Delivery retries exhausted for blind 0x%06lx",
+             static_cast<unsigned long>(this->command_.blind_addr));
     this->parent_->increment_tx_drop_count();
     if (outcome.intent.kind == CommandIntentKind::STOP && this->pending_stop_transition_) {
       this->pending_stop_transition_ = false;
@@ -221,7 +223,8 @@ void EleroCover::handle_delivery_outcome_(const DeliveryOutcome &outcome) {
       this->publish_state(false);
     }
   } else if (outcome.event == DeliveryEvent::STALE_CLEARED) {
-    ESP_LOGW(TAG, "Stale Command queue cleared for blind 0x%06x", this->command_.blind_addr);
+    ESP_LOGW(TAG, "Stale Command queue cleared for blind 0x%06lx",
+             static_cast<unsigned long>(this->command_.blind_addr));
     this->parent_->increment_tx_drop_count();
     if (outcome.intent.kind == CommandIntentKind::STOP && this->pending_stop_transition_) {
       this->pending_stop_transition_ = false;
@@ -262,7 +265,8 @@ IntentSubmitResult EleroCover::submit_intent(const CommandIntent &intent) {
   const bool deferred = this->should_defer_intent(intent);
   auto result = this->delivery_.submit(intent, millis(), deferred);
   if (result == IntentSubmitResult::REJECTED) {
-    ESP_LOGW(TAG, "Command queue full for blind 0x%06x", this->command_.blind_addr);
+    ESP_LOGW(TAG, "Command queue full for blind 0x%06lx",
+             static_cast<unsigned long>(this->command_.blind_addr));
 #ifdef USE_TEXT_SENSOR
     if (!this->queue_full_published_) {
       this->parent_->publish_text_sensor_state(this->command_.blind_addr, "queue_full");
@@ -290,7 +294,8 @@ cover::CoverTraits EleroCover::get_traits() {
 
 void EleroCover::set_rx_state(uint8_t state) {
   this->last_state_raw_ = state;
-  ESP_LOGV(TAG, "Got state: 0x%02x (%s) for blind 0x%06x", state, elero_state_to_string(state), this->command_.blind_addr);
+  ESP_LOGV(TAG, "Got state: 0x%02x (%s) for blind 0x%06lx", state, elero_state_to_string(state),
+           static_cast<unsigned long>(this->command_.blind_addr));
   float pos = this->position;
   float current_tilt = this->tilt;
   CoverOperation op = this->current_operation;
@@ -340,21 +345,21 @@ void EleroCover::set_rx_state(uint8_t state) {
     current_tilt = 0.0;
     break;
   case ELERO_STATE_BLOCKING:
-    ESP_LOGW(TAG, "Blind 0x%06x reports BLOCKING", this->command_.blind_addr);
+    ESP_LOGW(TAG, "Blind 0x%06lx reports BLOCKING", static_cast<unsigned long>(this->command_.blind_addr));
     op = COVER_OPERATION_IDLE;
 #ifdef USE_TEXT_SENSOR
     this->parent_->publish_text_sensor_state(this->command_.blind_addr, "blocking");
 #endif
     break;
   case ELERO_STATE_OVERHEATED:
-    ESP_LOGW(TAG, "Blind 0x%06x reports OVERHEATED", this->command_.blind_addr);
+    ESP_LOGW(TAG, "Blind 0x%06lx reports OVERHEATED", static_cast<unsigned long>(this->command_.blind_addr));
     op = COVER_OPERATION_IDLE;
 #ifdef USE_TEXT_SENSOR
     this->parent_->publish_text_sensor_state(this->command_.blind_addr, "overheated");
 #endif
     break;
   case ELERO_STATE_TIMEOUT:
-    ESP_LOGW(TAG, "Blind 0x%06x reports TIMEOUT", this->command_.blind_addr);
+    ESP_LOGW(TAG, "Blind 0x%06lx reports TIMEOUT", static_cast<unsigned long>(this->command_.blind_addr));
     op = COVER_OPERATION_IDLE;
 #ifdef USE_TEXT_SENSOR
     this->parent_->publish_text_sensor_state(this->command_.blind_addr, "timeout");
@@ -375,8 +380,8 @@ void EleroCover::set_rx_state(uint8_t state) {
         this->stop_verify_retries_ < ELERO_STOP_VERIFY_MAX_RETRIES) {
       // Motor is still moving and retries remain — re-send stop via priority queue
       this->stop_verify_retries_++;
-      ESP_LOGW(TAG, "Blind 0x%06x still moving after stop, retry #%d",
-               this->command_.blind_addr, this->stop_verify_retries_);
+      ESP_LOGW(TAG, "Blind 0x%06lx still moving after stop, retry #%d",
+               static_cast<unsigned long>(this->command_.blind_addr), this->stop_verify_retries_);
       this->submit_intent({CommandIntentKind::STOP, 0});
       this->stop_verify_at_ = millis() + ELERO_STOP_VERIFY_DELAY_MS;
       op = COVER_OPERATION_IDLE;  // keep our side idle while retrying
@@ -393,8 +398,9 @@ void EleroCover::set_rx_state(uint8_t state) {
           pos = clamp(this->stop_trigger_position_ + overshoot, 0.0f, 1.0f);
         else
           pos = clamp(this->stop_trigger_position_ - overshoot, 0.0f, 1.0f);
-        ESP_LOGD(TAG, "Blind 0x%06x stop verified: corrected pos %.2f -> %.2f (delay %ums)",
-                 this->command_.blind_addr, this->stop_trigger_position_, pos, actual_delay);
+        ESP_LOGD(TAG, "Blind 0x%06lx stop verified: corrected pos %.2f -> %.2f (delay %lums)",
+                 static_cast<unsigned long>(this->command_.blind_addr), this->stop_trigger_position_, pos,
+                 static_cast<unsigned long>(actual_delay));
       }
       this->stop_trigger_ms_ = 0;
       this->stop_verify_retries_ = ELERO_STOP_VERIFY_MAX_RETRIES;
@@ -426,8 +432,8 @@ void EleroCover::control(const cover::CoverCall &call) {
     if (std::isnan(cur)) {
       cur = 0.5f;
       this->position = cur;
-      ESP_LOGW(TAG, "Blind 0x%06x position was NAN, reset to 0.5",
-               this->command_.blind_addr);
+      ESP_LOGW(TAG, "Blind 0x%06lx position was NAN, reset to 0.5",
+               static_cast<unsigned long>(this->command_.blind_addr));
     }
     // Short-circuit: already at fully open/closed — skip movement entirely.
     // Without this, commanding 100% when already at 100% sends a redundant
@@ -497,8 +503,8 @@ void EleroCover::start_movement(CoverOperation dir) {
       this->pending_movement_kind_ = CommandIntentKind::CLOSE;
     break;
     case COVER_OPERATION_IDLE:
-      ESP_LOGI(TAG, "Blind 0x%06x manual stop at position %.2f",
-               this->command_.blind_addr, this->position);
+      ESP_LOGI(TAG, "Blind 0x%06lx manual stop at position %.2f",
+               static_cast<unsigned long>(this->command_.blind_addr), this->position);
       this->stop_trigger_position_ = this->position;
       this->stop_trigger_ms_ = millis();
       this->stop_verification_active_.store(true);
@@ -570,8 +576,8 @@ void EleroCover::recompute_position() {
   // Sanity check: skip recompute if elapsed time is implausibly large
   // (e.g., millis() wraparound glitch or stale last_recompute_time_)
   if (elapsed > ELERO_TIMEOUT_MOVEMENT) {
-    ESP_LOGW(TAG, "Position recompute skipped for blind 0x%06x: elapsed %u ms exceeds timeout",
-             this->command_.blind_addr, elapsed);
+    ESP_LOGW(TAG, "Position recompute skipped for blind 0x%06lx: elapsed %lu ms exceeds timeout",
+             static_cast<unsigned long>(this->command_.blind_addr), static_cast<unsigned long>(elapsed));
     this->last_recompute_time_ = now;
     return;
   }

--- a/components/elero/elero.cpp
+++ b/components/elero/elero.cpp
@@ -159,7 +159,12 @@ Elero::~Elero() {
   if (this->gdo0_pin_ != nullptr) {
     this->gdo0_pin_->detach_interrupt();
   }
+  // RadioLib's CC1101 is polymorphic but this pointer always owns the exact
+  // concrete type, so deleting it here is safe despite its non-virtual destructor.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdelete-non-virtual-dtor"
   delete this->radio_;
+#pragma GCC diagnostic pop
   this->radio_ = nullptr;
   delete this->radio_module_;
   this->radio_module_ = nullptr;
@@ -358,14 +363,15 @@ void Elero::dump_config() {
   ESP_LOGCONFIG(TAG, "Elero CC1101:");
   LOG_PIN("  GDO0 Pin: ", this->gdo0_pin_);
   ESP_LOGCONFIG(TAG, "  freq2: 0x%02x, freq1: 0x%02x, freq0: 0x%02x", this->freq2_, this->freq1_, this->freq0_);
-  ESP_LOGCONFIG(TAG, "  Send repeats: %d, send delay: %d ms, dedup window: %lu ms",
-                this->send_repeats_, this->send_delay_, (unsigned long) this->dedup_window_ms_);
+  ESP_LOGCONFIG(TAG, "  Send repeats: %d, send delay: %lu ms, dedup window: %lu ms",
+                this->send_repeats_, static_cast<unsigned long>(this->send_delay_),
+                static_cast<unsigned long>(this->dedup_window_ms_));
   ESP_LOGCONFIG(TAG, "  RadioLib: begin() + standby() + setFrequency(); direct SPI for register access");
   if (this->spi_failed_.load(std::memory_order_acquire)) {
     ESP_LOGCONFIG(TAG, "  SPI Status: FAILED — CC1101 communication broken");
     ESP_LOGCONFIG(TAG, "  Check SPI pin assignments — avoid ESP32 strapping pins (GPIO0/2/5/12/15)");
   }
-  ESP_LOGCONFIG(TAG, "  Registered covers: %d", this->address_to_cover_mapping_.size());
+  ESP_LOGCONFIG(TAG, "  Registered covers: %d", static_cast<int>(this->address_to_cover_mapping_.size()));
 }
 
 void Elero::setup() {
@@ -532,7 +538,7 @@ SendResult Elero::send_command(t_elero_command *cmd) {
     this->observe_tx_queue_depth_();
     return SendResult::OK;
   }
-  ESP_LOGV(TAG, "TX queue full, will retry for 0x%06x", cmd->blind_addr);
+  ESP_LOGV(TAG, "TX queue full, will retry for 0x%06lx", static_cast<unsigned long>(cmd->blind_addr));
   return SendResult::QUEUE_FULL;
 }
 
@@ -560,7 +566,7 @@ SendResult Elero::send_command_priority(t_elero_command *cmd) {
     this->observe_tx_queue_depth_();
     return SendResult::OK;
   }
-  ESP_LOGV(TAG, "Priority TX queue full, will retry for 0x%06x", cmd->blind_addr);
+  ESP_LOGV(TAG, "Priority TX queue full, will retry for 0x%06lx", static_cast<unsigned long>(cmd->blind_addr));
   return SendResult::QUEUE_FULL;
 }
 
@@ -620,18 +626,22 @@ void Elero::observe_dispatch_latency_(uint32_t decoded_at_ms) {
 void EleroRefreshButton::dump_config() {
   LOG_BUTTON("", "Elero Refresh Button", this);
   if (this->blind_ != nullptr) {
-    ESP_LOGCONFIG(TAG, "  Target: cover 0x%06x", this->blind_->get_blind_address());
+    ESP_LOGCONFIG(TAG, "  Target: cover 0x%06lx",
+                  static_cast<unsigned long>(this->blind_->get_blind_address()));
   } else if (this->light_ != nullptr) {
-    ESP_LOGCONFIG(TAG, "  Target: light 0x%06x", this->light_->get_blind_address());
+    ESP_LOGCONFIG(TAG, "  Target: light 0x%06lx",
+                  static_cast<unsigned long>(this->light_->get_blind_address()));
   }
 }
 
 void EleroRefreshButton::press_action() {
   if (this->blind_ != nullptr) {
-    ESP_LOGD(TAG, "Refresh: CHECK → cover 0x%06x", this->blind_->get_blind_address());
+    ESP_LOGD(TAG, "Refresh: CHECK → cover 0x%06lx",
+             static_cast<unsigned long>(this->blind_->get_blind_address()));
     this->blind_->submit_intent({CommandIntentKind::CHECK, 0});
   } else if (this->light_ != nullptr) {
-    ESP_LOGD(TAG, "Refresh: CHECK → light 0x%06x", this->light_->get_blind_address());
+    ESP_LOGD(TAG, "Refresh: CHECK → light 0x%06lx",
+             static_cast<unsigned long>(this->light_->get_blind_address()));
     this->light_->submit_intent({CommandIntentKind::CHECK, 0});
   }
 }

--- a/components/elero/elero_cc1101.cpp
+++ b/components/elero/elero_cc1101.cpp
@@ -514,8 +514,8 @@ bool Elero::init() {
     }
     if (attempt < max_spi_retries) {
       uint32_t delay_us = 2000u * (1u << (attempt - 1));
-      ESP_LOGW(TAG, "init: SPI health check attempt %d/%d failed (wrote 0x08, read 0x%02x), retrying in %u us",
-               attempt, max_spi_retries, check, delay_us);
+      ESP_LOGW(TAG, "init: SPI health check attempt %d/%d failed (wrote 0x08, read 0x%02x), retrying in %lu us",
+               attempt, max_spi_retries, check, static_cast<unsigned long>(delay_us));
       delay_microseconds_safe(delay_us);
     } else {
       ESP_LOGE(TAG, "init: SPI health check failed after %d attempts (wrote 0x08, read 0x%02x) — aborting init",
@@ -708,8 +708,8 @@ bool Elero::send_command_internal_(t_elero_command *cmd, uint32_t enqueued_at_ms
   crypto::msg_encode(payload);
 
   if (num_dests == 1) {
-    ESP_LOGD(TAG, "send to 0x%06x: cmd=0x%02x ch=%02d cnt=%02d",
-             cmd->dest_addrs[0], cmd->payload[4], cmd->channel, cmd->counter);
+    ESP_LOGD(TAG, "send to 0x%06lx: cmd=0x%02x ch=%02d cnt=%02d",
+             static_cast<unsigned long>(cmd->dest_addrs[0]), cmd->payload[4], cmd->channel, cmd->counter);
   } else {
     ESP_LOGD(TAG, "send group (%d dests): cmd=0x%02x ch=%02d cnt=%02d",
              num_dests, cmd->payload[4], cmd->channel, cmd->counter);

--- a/components/elero/elero_discovery.cpp
+++ b/components/elero/elero_discovery.cpp
@@ -78,8 +78,8 @@ void Elero::track_discovered_blind(uint32_t src, uint32_t remote, uint8_t channe
         blind.payload_1 = payload_1;
         blind.payload_2 = payload_2;
         blind.params_from_command = true;
-        ESP_LOGI(TAG, "Upgraded blind 0x%06x params from command packet: ch=%d, pck_inf=0x%02x/0x%02x, hop=0x%02x, payload=0x%02x/0x%02x",
-                 src, channel, pck_inf0, pck_inf1, hop, payload_1, payload_2);
+        ESP_LOGI(TAG, "Upgraded blind 0x%06lx params from command packet: ch=%d, pck_inf=0x%02x/0x%02x, hop=0x%02x, payload=0x%02x/0x%02x",
+                 static_cast<unsigned long>(src), channel, pck_inf0, pck_inf1, hop, payload_1, payload_2);
       }
       return;
     }
@@ -100,8 +100,9 @@ void Elero::track_discovered_blind(uint32_t src, uint32_t remote, uint8_t channe
     blind.times_seen = 1;
     blind.params_from_command = from_command;
     this->discovered_blinds_.push_back(blind);
-    ESP_LOGI(TAG, "Discovered new device: addr=0x%06x, remote=0x%06x, ch=%d, rssi=%.1f, src=%s",
-             src, remote, channel, rssi, from_command ? "cmd_pkt" : "status_pkt");
+    ESP_LOGI(TAG, "Discovered new device: addr=0x%06lx, remote=0x%06lx, ch=%d, rssi=%.1f, src=%s",
+             static_cast<unsigned long>(src), static_cast<unsigned long>(remote), channel, rssi,
+             from_command ? "cmd_pkt" : "status_pkt");
   }
 }
 

--- a/components/elero/elero_protocol.cpp
+++ b/components/elero/elero_protocol.cpp
@@ -67,7 +67,8 @@ void Elero::interpret_msg() {
       this->mark_last_raw_packet_(true, nullptr);
       this->packet_dump_pending_update_ = false;
     }
-    ESP_LOGV(TAG, "Duplicate status from 0x%06x cnt=%d (relay hop), skipping", packet.src, packet.cnt);
+    ESP_LOGV(TAG, "Duplicate status from 0x%06lx cnt=%d (relay hop), skipping",
+             static_cast<unsigned long>(packet.src), packet.cnt);
     return;
   }
 
@@ -82,8 +83,8 @@ void Elero::interpret_msg() {
           counter_it->second, packet.cnt, last_counter_activity_ms, now_ms, has_counter_activity);
       if (!decision.accept) {
         this->last_seen_counter_ms_[packet.src] = decision.next_activity_ms;
-        ESP_LOGV(TAG, "Stale status counter from 0x%06x cnt=%d last=%d, dropping",
-                 packet.src, packet.cnt, counter_it->second);
+        ESP_LOGV(TAG, "Stale status counter from 0x%06lx cnt=%d last=%d, dropping",
+                 static_cast<unsigned long>(packet.src), packet.cnt, counter_it->second);
         this->increment_parser_drop_count("stale_counter");
         if (this->packet_dump_pending_update_) {
           this->mark_last_raw_packet_(false, "stale_counter");
@@ -92,8 +93,8 @@ void Elero::interpret_msg() {
         return;
       }
       if (counter_logic::is_stale_counter(counter_it->second, packet.cnt)) {
-        ESP_LOGD(TAG, "Resyncing status counter from 0x%06x cnt=%d last=%d after %lums gap",
-                 packet.src, packet.cnt, counter_it->second,
+        ESP_LOGD(TAG, "Resyncing status counter from 0x%06lx cnt=%d last=%d after %lums gap",
+                 static_cast<unsigned long>(packet.src), packet.cnt, counter_it->second,
                  static_cast<unsigned long>(has_counter_activity
                                                ? static_cast<uint32_t>(now_ms - last_counter_activity_ms)
                                                : 0u));
@@ -109,8 +110,9 @@ void Elero::interpret_msg() {
   }
 
   this->rx_count_.fetch_add(1, std::memory_order_relaxed);
-  ESP_LOGD(TAG, "rcv'd from 0x%06x: state=0x%02x rssi=%.1f", packet.src, packet.payload[6], packet.rssi);
-  ESP_LOGV(TAG, "rcv'd: len=%02d, cnt=%02d, typ=0x%02x, typ2=0x%02x, hop=0x%02x, syst=0x%02x, chl=%02d, src=0x%06x, bwd=0x%06x, fwd=0x%06x, #dst=%02d, dst=0x%06x, rssi=%2.1f, lqi=%2d, crc=%2d, payload=[0x%02x 0x%02x 0x%02x 0x%02x 0x%02x 0x%02x 0x%02x 0x%02x 0x%02x 0x%02x]", packet.length, packet.cnt, packet.typ, packet.typ2, packet.hop, packet.syst, packet.channel, packet.src, packet.bwd, packet.fwd, packet.num_dests, packet.first_dst, packet.rssi, packet.lqi, packet.crc, packet.payload_1, packet.payload_2, packet.payload[0], packet.payload[1], packet.payload[2], packet.payload[3], packet.payload[4], packet.payload[5], packet.payload[6], packet.payload[7]);
+  ESP_LOGD(TAG, "rcv'd from 0x%06lx: state=0x%02x rssi=%.1f",
+           static_cast<unsigned long>(packet.src), packet.payload[6], packet.rssi);
+  ESP_LOGV(TAG, "rcv'd: len=%02d, cnt=%02d, typ=0x%02x, typ2=0x%02x, hop=0x%02x, syst=0x%02x, chl=%02d, src=0x%06lx, bwd=0x%06lx, fwd=0x%06lx, #dst=%02d, dst=0x%06lx, rssi=%2.1f, lqi=%2d, crc=%2d, payload=[0x%02x 0x%02x 0x%02x 0x%02x 0x%02x 0x%02x 0x%02x 0x%02x 0x%02x 0x%02x]", packet.length, packet.cnt, packet.typ, packet.typ2, packet.hop, packet.syst, packet.channel, static_cast<unsigned long>(packet.src), static_cast<unsigned long>(packet.bwd), static_cast<unsigned long>(packet.fwd), packet.num_dests, static_cast<unsigned long>(packet.first_dst), packet.rssi, packet.lqi, packet.crc, packet.payload_1, packet.payload_2, packet.payload[0], packet.payload[1], packet.payload[2], packet.payload[3], packet.payload[4], packet.payload[5], packet.payload[6], packet.payload[7]);
 
   RxResult rx{};
   rx.blind_address = packet.src;
@@ -144,7 +146,7 @@ void Elero::interpret_msg() {
 
   if (this->rx_queue_) {
     if (xQueueSend(this->rx_queue_, &rx, 0) != pdTRUE) {
-      ESP_LOGW(TAG, "RX queue full, dropping packet from 0x%06x", packet.src);
+      ESP_LOGW(TAG, "RX queue full, dropping packet from 0x%06lx", static_cast<unsigned long>(packet.src));
     }
   }
 }

--- a/components/elero/elero_runtime.cpp
+++ b/components/elero/elero_runtime.cpp
@@ -21,7 +21,8 @@ void Elero::poll_runtime_blinds_() {
                            now, rb.last_poll_ms, rb.poll_intvl_ms, rb.delivery->empty())) {
       if (intent_was_accepted(rb.delivery->submit({CommandIntentKind::CHECK, 0}, now))) {
         rb.last_poll_ms = now;
-        ESP_LOGD(TAG, "Periodic poll for runtime blind 0x%06x", rb.blind_address);
+        ESP_LOGD(TAG, "Periodic poll for runtime blind 0x%06lx",
+                 static_cast<unsigned long>(rb.blind_address));
       }
     }
   }
@@ -111,10 +112,12 @@ bool Elero::adopt_blind(const DiscoveredBlind &discovered, const std::string &na
   rb.delivery = std::make_shared<CommandIntentDelivery>(delivery_config);
   rb.delivery->set_outcome_callback([this, address = discovered.blind_address](const DeliveryOutcome &outcome) {
     if (outcome.event == DeliveryEvent::DROPPED) {
-      ESP_LOGE(TAG, "Delivery retries exhausted for runtime blind 0x%06x", address);
+      ESP_LOGE(TAG, "Delivery retries exhausted for runtime blind 0x%06lx",
+               static_cast<unsigned long>(address));
       this->increment_tx_drop_count();
     } else if (outcome.event == DeliveryEvent::STALE_CLEARED) {
-      ESP_LOGW(TAG, "Stale Command queue cleared for runtime blind 0x%06x", address);
+      ESP_LOGW(TAG, "Stale Command queue cleared for runtime blind 0x%06lx",
+               static_cast<unsigned long>(address));
       this->increment_tx_drop_count();
     }
   });
@@ -123,9 +126,9 @@ bool Elero::adopt_blind(const DiscoveredBlind &discovered, const std::string &na
   const std::string adopted_name = rb.name;
   this->runtime_blinds_.insert({discovered.blind_address, std::move(rb)});
   this->own_remote_addresses_.insert(discovered.remote_address);
-  ESP_LOGI(TAG, "Adopted runtime %s 0x%06x as \"%s\"",
+  ESP_LOGI(TAG, "Adopted runtime %s 0x%06lx as \"%s\"",
            type == DeviceType::LIGHT ? "light" : "blind",
-           discovered.blind_address, adopted_name.c_str());
+           static_cast<unsigned long>(discovered.blind_address), adopted_name.c_str());
   return true;
 }
 
@@ -133,7 +136,7 @@ bool Elero::remove_runtime_blind(uint32_t addr) {
   std::lock_guard<std::mutex> lock(state_mutex_);
   auto it = this->runtime_blinds_.find(addr);
   if (it != this->runtime_blinds_.end()) {
-    ESP_LOGI(TAG, "Removed runtime blind 0x%06x", addr);
+    ESP_LOGI(TAG, "Removed runtime blind 0x%06lx", static_cast<unsigned long>(addr));
     this->unregister_command_delivery(it->second.delivery.get());
     this->runtime_blinds_.erase(it);
     return true;

--- a/components/elero/light/EleroLight.cpp
+++ b/components/elero/light/EleroLight.cpp
@@ -12,14 +12,14 @@ static const char *const TAG = "elero.light";
 
 void EleroLight::dump_config() {
   ESP_LOGCONFIG(TAG, "Elero Light:");
-  ESP_LOGCONFIG(TAG, "  Blind Address: 0x%06x", this->command_.blind_addr);
-  ESP_LOGCONFIG(TAG, "  Remote Address: 0x%06x", this->command_.remote_addr);
+  ESP_LOGCONFIG(TAG, "  Blind Address: 0x%06lx", static_cast<unsigned long>(this->command_.blind_addr));
+  ESP_LOGCONFIG(TAG, "  Remote Address: 0x%06lx", static_cast<unsigned long>(this->command_.remote_addr));
   ESP_LOGCONFIG(TAG, "  Channel: %d", this->command_.channel);
   ESP_LOGCONFIG(TAG, "  Hop: 0x%02x", this->command_.hop);
   ESP_LOGCONFIG(TAG, "  pck_inf1: 0x%02x, pck_inf2: 0x%02x",
                 this->command_.pck_inf[0], this->command_.pck_inf[1]);
   if (this->dim_duration_ > 0)
-    ESP_LOGCONFIG(TAG, "  Dim Duration: %dms", this->dim_duration_);
+    ESP_LOGCONFIG(TAG, "  Dim Duration: %lums", static_cast<unsigned long>(this->dim_duration_));
   ESP_LOGCONFIG(TAG, "  cmd_on: 0x%02x, cmd_off: 0x%02x, cmd_stop: 0x%02x",
                 this->command_on_, this->command_off_, this->command_stop_);
   ESP_LOGCONFIG(TAG, "  cmd_dim_up: 0x%02x, cmd_dim_down: 0x%02x",
@@ -104,8 +104,8 @@ void EleroLight::write_state(LightState *state) {
   this->is_dimming_ = start_dimming;
   this->pending_dimming_start_ = start_dimming;
   if (start_dimming) {
-    ESP_LOGD(TAG, "Dimming %s 0x%06x from %.2f to %.2f", dim_up ? "up" : "down",
-             this->command_.blind_addr, this->brightness_, new_brightness);
+    ESP_LOGD(TAG, "Dimming %s 0x%06lx from %.2f to %.2f", dim_up ? "up" : "down",
+             static_cast<unsigned long>(this->command_.blind_addr), this->brightness_, new_brightness);
     this->dim_up_ = dim_up;
     this->pending_dimming_kind_ = dim_up ? CommandIntentKind::DIM_UP : CommandIntentKind::DIM_DOWN;
     this->dimming_start_ = 0;
@@ -148,14 +148,16 @@ void EleroLight::handle_delivery_outcome_(const DeliveryOutcome &outcome) {
   }
 
   if (outcome.event == DeliveryEvent::DROPPED) {
-    ESP_LOGE(TAG, "Delivery retries exhausted for light 0x%06x", this->command_.blind_addr);
+    ESP_LOGE(TAG, "Delivery retries exhausted for light 0x%06lx",
+             static_cast<unsigned long>(this->command_.blind_addr));
     this->parent_->increment_tx_drop_count();
     if (this->pending_dimming_start_ && outcome.intent.kind == this->pending_dimming_kind_) {
       this->pending_dimming_start_ = false;
       this->is_dimming_ = false;
     }
   } else if (outcome.event == DeliveryEvent::STALE_CLEARED) {
-    ESP_LOGW(TAG, "Stale Command queue cleared for light 0x%06x", this->command_.blind_addr);
+    ESP_LOGW(TAG, "Stale Command queue cleared for light 0x%06lx",
+             static_cast<unsigned long>(this->command_.blind_addr));
     this->parent_->increment_tx_drop_count();
     if (this->pending_dimming_start_) {
       this->pending_dimming_start_ = false;
@@ -194,7 +196,8 @@ IntentSubmitResult EleroLight::submit_intent(const CommandIntent &intent) {
 IntentSubmitResult EleroLight::submit_intents_(const std::vector<CommandIntent> &intents) {
   auto result = this->delivery_.submit_batch(intents.data(), intents.size(), millis());
   if (result == IntentSubmitResult::REJECTED) {
-    ESP_LOGW(TAG, "Command queue full for light 0x%06x", this->command_.blind_addr);
+    ESP_LOGW(TAG, "Command queue full for light 0x%06lx",
+             static_cast<unsigned long>(this->command_.blind_addr));
 #ifdef USE_TEXT_SENSOR
     if (!this->queue_full_published_) {
       this->parent_->publish_text_sensor_state(this->command_.blind_addr, "queue_full");
@@ -233,8 +236,8 @@ void EleroLight::recompute_brightness() {
 }
 
 void EleroLight::set_rx_state(uint8_t state) {
-  ESP_LOGV(TAG, "Got state: 0x%02x for light 0x%06x",
-           state, this->command_.blind_addr);
+  ESP_LOGV(TAG, "Got state: 0x%02x for light 0x%06lx",
+           state, static_cast<unsigned long>(this->command_.blind_addr));
 
   if (state == ELERO_STATE_ON) {
     if (!this->is_on_) {
@@ -263,17 +266,17 @@ void EleroLight::set_rx_state(uint8_t state) {
       }
     }
   } else if (state == ELERO_STATE_BLOCKING) {
-    ESP_LOGW(TAG, "Light 0x%06x reports BLOCKING", this->command_.blind_addr);
+    ESP_LOGW(TAG, "Light 0x%06lx reports BLOCKING", static_cast<unsigned long>(this->command_.blind_addr));
 #ifdef USE_TEXT_SENSOR
     this->parent_->publish_text_sensor_state(this->command_.blind_addr, "blocking");
 #endif
   } else if (state == ELERO_STATE_OVERHEATED) {
-    ESP_LOGW(TAG, "Light 0x%06x reports OVERHEATED", this->command_.blind_addr);
+    ESP_LOGW(TAG, "Light 0x%06lx reports OVERHEATED", static_cast<unsigned long>(this->command_.blind_addr));
 #ifdef USE_TEXT_SENSOR
     this->parent_->publish_text_sensor_state(this->command_.blind_addr, "overheated");
 #endif
   } else if (state == ELERO_STATE_TIMEOUT) {
-    ESP_LOGW(TAG, "Light 0x%06x reports TIMEOUT", this->command_.blind_addr);
+    ESP_LOGW(TAG, "Light 0x%06lx reports TIMEOUT", static_cast<unsigned long>(this->command_.blind_addr));
 #ifdef USE_TEXT_SENSOR
     this->parent_->publish_text_sensor_state(this->command_.blind_addr, "timeout");
 #endif

--- a/components/elero_group/EleroGroupCover.cpp
+++ b/components/elero_group/EleroGroupCover.cpp
@@ -42,12 +42,14 @@ void EleroGroupCover::loop() {
 
 void EleroGroupCover::dump_config() {
   ESP_LOGCONFIG(TAG, "Elero Group Cover '%s':", this->get_name().c_str());
-  ESP_LOGCONFIG(TAG, "  Members: %d", (int) this->members_.size());
+  ESP_LOGCONFIG(TAG, "  Members: %d", static_cast<int>(this->members_.size()));
   ESP_LOGCONFIG(TAG, "  Native multi-dest: %s", this->native_group_ ? "yes" : "no (incompatible profiles)");
   ESP_LOGCONFIG(TAG, "  Hide members: %s", YESNO(this->hide_members_));
-  for (auto *member : this->members_)
-    ESP_LOGCONFIG(TAG, "    - 0x%06x (ch=%d, remote=0x%06x)", member->get_blind_address(),
-                  member->get_channel(), member->get_remote_address());
+  for (auto *member : this->members_) {
+    ESP_LOGCONFIG(TAG, "    - 0x%06lx (ch=%d, remote=0x%06lx)",
+                  static_cast<unsigned long>(member->get_blind_address()), member->get_channel(),
+                  static_cast<unsigned long>(member->get_remote_address()));
+  }
 }
 
 cover::CoverTraits EleroGroupCover::get_traits() {

--- a/components/elero_web/elero_web_server.cpp
+++ b/components/elero_web/elero_web_server.cpp
@@ -380,8 +380,8 @@ void EleroWebServer::build_discovered_array_json_(std::string &out) {
 
     char buf[640];
     snprintf(buf, sizeof(buf),
-      "{\"blind_address\":\"0x%06x\","
-      "\"remote_address\":\"0x%06x\","
+      "{\"blind_address\":\"0x%06lx\","
+      "\"remote_address\":\"0x%06lx\","
       "\"channel\":%d,"
       "\"rssi\":%.1f,"
       "\"last_state\":\"%s\","
@@ -396,8 +396,8 @@ void EleroWebServer::build_discovered_array_json_(std::string &out) {
       "\"already_configured\":%s,"
       "\"configured_as\":\"%s\","
       "\"already_adopted\":%s}",
-      blind.blind_address,
-      blind.remote_address,
+      static_cast<unsigned long>(blind.blind_address),
+      static_cast<unsigned long>(blind.remote_address),
       blind.channel,
       blind.rssi,
       elero_state_to_string(blind.last_state),
@@ -448,7 +448,7 @@ void EleroWebServer::build_configured_json_(std::string &out) {
     std::string esc_name = json_escape(blind->get_blind_name());
     char buf[512];
     snprintf(buf, sizeof(buf),
-      "{\"blind_address\":\"0x%06x\","
+      "{\"blind_address\":\"0x%06lx\","
       "\"name\":\"%s\","
       "\"position\":%.2f,"
       "\"operation\":\"%s\","
@@ -456,14 +456,14 @@ void EleroWebServer::build_configured_json_(std::string &out) {
       "\"last_seen_ms\":%lu,"
       "\"rssi\":%.1f,"
       "\"channel\":%d,"
-      "\"remote_address\":\"0x%06x\","
+      "\"remote_address\":\"0x%06lx\","
       "\"poll_interval_ms\":%lu,"
       "\"open_duration_ms\":%lu,"
       "\"close_duration_ms\":%lu,"
       "\"supports_tilt\":%s,"
       "\"device_type\":\"cover\","
       "\"adopted\":false}",
-      pair.first,
+      static_cast<unsigned long>(pair.first),
       esc_name.c_str(),
       blind->get_cover_position(),
       blind->get_operation_str(),
@@ -471,7 +471,7 @@ void EleroWebServer::build_configured_json_(std::string &out) {
       (unsigned long)blind->get_last_seen_ms(),
       blind->get_last_rssi(),
       (int)blind->get_channel(),
-      blind->get_remote_address(),
+      static_cast<unsigned long>(blind->get_remote_address()),
       (unsigned long)blind->get_poll_interval_ms(),
       (unsigned long)blind->get_open_duration_ms(),
       (unsigned long)blind->get_close_duration_ms(),
@@ -503,7 +503,7 @@ void EleroWebServer::build_configured_json_(std::string &out) {
 
     char buf[512];
     snprintf(buf, sizeof(buf),
-      "{\"blind_address\":\"0x%06x\","
+      "{\"blind_address\":\"0x%06lx\","
       "\"name\":\"%s\","
       "\"position\":%s,"
       "\"operation\":\"%s\","
@@ -511,14 +511,14 @@ void EleroWebServer::build_configured_json_(std::string &out) {
       "\"last_seen_ms\":%lu,"
       "\"rssi\":%.1f,"
       "\"channel\":%d,"
-      "\"remote_address\":\"0x%06x\","
+      "\"remote_address\":\"0x%06lx\","
       "\"poll_interval_ms\":%lu,"
       "\"open_duration_ms\":%lu,"
       "\"close_duration_ms\":%lu,"
       "\"supports_tilt\":false,"
       "\"device_type\":\"cover\","
       "\"adopted\":true}",
-      rb.blind_address,
+      static_cast<unsigned long>(rb.blind_address),
       esc_name.c_str(),
       pos_str,
       operation,
@@ -526,7 +526,7 @@ void EleroWebServer::build_configured_json_(std::string &out) {
       (unsigned long)rb.last_seen_ms,
       rb.last_rssi,
       (int)rb.channel,
-      rb.remote_address,
+      static_cast<unsigned long>(rb.remote_address),
       (unsigned long)rb.poll_intvl_ms,
       (unsigned long)rb.open_duration_ms,
       (unsigned long)rb.close_duration_ms
@@ -546,7 +546,7 @@ void EleroWebServer::build_configured_json_(std::string &out) {
     std::string esc_name = json_escape(light->get_light_name());
     char buf[512];
     snprintf(buf, sizeof(buf),
-      "{\"blind_address\":\"0x%06x\","
+      "{\"blind_address\":\"0x%06lx\","
       "\"name\":\"%s\","
       "\"is_on\":%s,"
       "\"brightness\":%.2f,"
@@ -555,11 +555,11 @@ void EleroWebServer::build_configured_json_(std::string &out) {
       "\"last_seen_ms\":%lu,"
       "\"rssi\":%.1f,"
       "\"channel\":%d,"
-      "\"remote_address\":\"0x%06x\","
+      "\"remote_address\":\"0x%06lx\","
       "\"dim_duration_ms\":%lu,"
       "\"device_type\":\"light\","
       "\"adopted\":false}",
-      pair.first,
+      static_cast<unsigned long>(pair.first),
       esc_name.c_str(),
       light->get_is_on() ? "true" : "false",
       light->get_brightness(),
@@ -568,7 +568,7 @@ void EleroWebServer::build_configured_json_(std::string &out) {
       (unsigned long)light->get_last_seen_ms(),
       light->get_last_rssi(),
       (int)light->get_channel(),
-      light->get_remote_address(),
+      static_cast<unsigned long>(light->get_remote_address()),
       (unsigned long)light->get_dim_duration_ms()
     );
     out += buf;
@@ -583,7 +583,7 @@ void EleroWebServer::build_configured_json_(std::string &out) {
     std::string esc_name = json_escape(rb.name);
     char buf[512];
     snprintf(buf, sizeof(buf),
-      "{\"blind_address\":\"0x%06x\","
+      "{\"blind_address\":\"0x%06lx\","
       "\"name\":\"%s\","
       "\"is_on\":false,"
       "\"brightness\":0.00,"
@@ -592,17 +592,17 @@ void EleroWebServer::build_configured_json_(std::string &out) {
       "\"last_seen_ms\":%lu,"
       "\"rssi\":%.1f,"
       "\"channel\":%d,"
-      "\"remote_address\":\"0x%06x\","
+      "\"remote_address\":\"0x%06lx\","
       "\"dim_duration_ms\":%lu,"
       "\"device_type\":\"light\","
       "\"adopted\":true}",
-      rb.blind_address,
+      static_cast<unsigned long>(rb.blind_address),
       esc_name.c_str(),
       elero_state_to_string(rb.last_state),
       (unsigned long)rb.last_seen_ms,
       rb.last_rssi,
       (int)rb.channel,
-      rb.remote_address,
+      static_cast<unsigned long>(rb.remote_address),
       (unsigned long)rb.dim_duration_ms
     );
     out += buf;
@@ -646,8 +646,8 @@ void EleroWebServer::handle_cover_command(AsyncWebServerRequest *request, uint32
       return;
     }
     char buf[96];
-    snprintf(buf, sizeof(buf), "{\"status\":\"queued\",\"address\":\"0x%06x\",\"cmd\":\"%s\"}",
-             addr, cmd_str.c_str());
+    snprintf(buf, sizeof(buf), "{\"status\":\"queued\",\"address\":\"0x%06lx\",\"cmd\":\"%s\"}",
+             static_cast<unsigned long>(addr), cmd_str.c_str());
     AsyncWebServerResponse *response = request->beginResponse(200, "application/json", buf);
     this->add_cors_headers(response);
     request->send(response);
@@ -749,7 +749,8 @@ void EleroWebServer::handle_cover_settings(AsyncWebServerRequest *request, uint3
 
     it->second->apply_runtime_settings(open_dur, close_dur, poll_intvl);
     char buf[80];
-    snprintf(buf, sizeof(buf), "{\"status\":\"ok\",\"address\":\"0x%06x\"}", addr);
+    snprintf(buf, sizeof(buf), "{\"status\":\"ok\",\"address\":\"0x%06lx\"}",
+             static_cast<unsigned long>(addr));
     AsyncWebServerResponse *response = request->beginResponse(200, "application/json", buf);
     this->add_cors_headers(response);
     request->send(response);
@@ -788,7 +789,8 @@ void EleroWebServer::handle_cover_settings(AsyncWebServerRequest *request, uint3
 
   if (this->parent_->update_runtime_blind_settings(addr, open_dur, close_dur, poll_intvl)) {
     char buf[80];
-    snprintf(buf, sizeof(buf), "{\"status\":\"ok\",\"address\":\"0x%06x\"}", addr);
+    snprintf(buf, sizeof(buf), "{\"status\":\"ok\",\"address\":\"0x%06lx\"}",
+             static_cast<unsigned long>(addr));
     AsyncWebServerResponse *response = request->beginResponse(200, "application/json", buf);
     this->add_cors_headers(response);
     request->send(response);
@@ -818,8 +820,8 @@ void EleroWebServer::handle_adopt_discovered(AsyncWebServerRequest *request, uin
       std::string display_name = name.empty() ? "Adopted" : name;
       std::string esc_name = json_escape(display_name);
       char buf[128];
-      snprintf(buf, sizeof(buf), "{\"status\":\"adopted\",\"address\":\"0x%06x\",\"name\":\"%s\"}",
-               addr, esc_name.c_str());
+      snprintf(buf, sizeof(buf), "{\"status\":\"adopted\",\"address\":\"0x%06lx\",\"name\":\"%s\"}",
+               static_cast<unsigned long>(addr), esc_name.c_str());
       AsyncWebServerResponse *response = request->beginResponse(200, "application/json", buf);
       this->add_cors_headers(response);
       request->send(response);
@@ -849,10 +851,10 @@ void EleroWebServer::handle_get_runtime(AsyncWebServerRequest *request) {
 
     char buf[448];
     snprintf(buf, sizeof(buf),
-      "{\"blind_address\":\"0x%06x\","
+      "{\"blind_address\":\"0x%06lx\","
       "\"name\":\"%s\","
       "\"channel\":%d,"
-      "\"remote_address\":\"0x%06x\","
+      "\"remote_address\":\"0x%06lx\","
       "\"rssi\":%.1f,"
       "\"last_state\":\"%s\","
       "\"last_seen_ms\":%lu,"
@@ -863,8 +865,8 @@ void EleroWebServer::handle_get_runtime(AsyncWebServerRequest *request) {
       "\"close_duration_ms\":%lu,"
       "\"dim_duration_ms\":%lu,"
       "\"poll_interval_ms\":%lu}",
-      rb.blind_address, esc_name.c_str(), (int)rb.channel,
-      rb.remote_address, rb.last_rssi,
+      static_cast<unsigned long>(rb.blind_address), esc_name.c_str(), (int)rb.channel,
+      static_cast<unsigned long>(rb.remote_address), rb.last_rssi,
       elero_state_to_string(rb.last_state),
       (unsigned long)rb.last_seen_ms,
       rb.device_type == DeviceType::LIGHT ? "light" : "cover",
@@ -895,7 +897,8 @@ void EleroWebServer::handle_runtime_settings(AsyncWebServerRequest *request, uin
 void EleroWebServer::handle_runtime_remove(AsyncWebServerRequest *request, uint32_t addr) {
   if (this->parent_->remove_runtime_blind(addr)) {
     char buf[64];
-    snprintf(buf, sizeof(buf), "{\"status\":\"removed\",\"address\":\"0x%06x\"}", addr);
+    snprintf(buf, sizeof(buf), "{\"status\":\"removed\",\"address\":\"0x%06lx\"}",
+             static_cast<unsigned long>(addr));
     AsyncWebServerResponse *response = request->beginResponse(200, "application/json", buf);
     this->add_cors_headers(response);
     request->send(response);
@@ -935,9 +938,9 @@ void EleroWebServer::handle_get_yaml(AsyncWebServerRequest *request) {
     snprintf(buf, sizeof(buf),
       "%s"
       "  - platform: elero\n"
-      "    blind_address: 0x%06x\n"
+      "    blind_address: 0x%06lx\n"
       "    channel: %d\n"
-      "    remote_address: 0x%06x\n"
+      "    remote_address: 0x%06lx\n"
       "    name: \"Discovered Blind %d\"\n"
       "    # open_duration: 25s\n"
       "    # close_duration: 22s\n"
@@ -951,7 +954,8 @@ void EleroWebServer::handle_get_yaml(AsyncWebServerRequest *request) {
         ? ""
         : "  # WARNING: params derived from status packet only — press a remote\n"
           "  # button during scan so command packets can be captured for reliable values.\n",
-      blind.blind_address, blind.channel, blind.remote_address, ++cover_idx,
+      static_cast<unsigned long>(blind.blind_address), blind.channel,
+      static_cast<unsigned long>(blind.remote_address), ++cover_idx,
       blind.hop, blind.payload_1, blind.payload_2, blind.pck_inf[0], blind.pck_inf[1]
     );
     yaml += buf;
@@ -977,9 +981,9 @@ void EleroWebServer::handle_get_yaml(AsyncWebServerRequest *request) {
     snprintf(buf, sizeof(buf),
       "%s"
       "  - platform: elero\n"
-      "    blind_address: 0x%06x\n"
+      "    blind_address: 0x%06lx\n"
       "    channel: %d\n"
-      "    remote_address: 0x%06x\n"
+      "    remote_address: 0x%06lx\n"
       "    name: \"Discovered Light %d\"\n"
       "    # dim_duration: 0s\n"
       "    hop: 0x%02x\n"
@@ -992,7 +996,8 @@ void EleroWebServer::handle_get_yaml(AsyncWebServerRequest *request) {
         ? ""
         : "  # WARNING: params derived from status packet only — press a remote\n"
           "  # button during scan so command packets can be captured for reliable values.\n",
-      blind.blind_address, blind.channel, blind.remote_address, ++light_idx,
+      static_cast<unsigned long>(blind.blind_address), blind.channel,
+      static_cast<unsigned long>(blind.remote_address), ++light_idx,
       blind.hop, blind.payload_1, blind.payload_2, blind.pck_inf[0], blind.pck_inf[1]
     );
     yaml += buf;


### PR DESCRIPTION
## Summary
- match ESPHome 2026.7 / ESP-IDF printf format specifiers to 32-bit address and timing argument types
- apply the same type-safe formatting to cover, light, group, runtime, discovery, protocol, and web output paths
- suppress RadioLib's non-virtual-destructor warning only at the exact concrete CC1101 delete site
- preserve the adopted runtime device name after moving its state into the map

## Validation
- [x] C++ unit suite: 261/261 passed
- [x] Markdown local-link validation
- [x] `git diff --check`
- [ ] ESPHome 2026.7 firmware compile (requires Python 3.12+; unavailable in this workspace)

The supplied device log confirms the firmware compiled and OTA upload completed successfully; this PR removes the component-owned compiler warnings exposed by that build.