### PR TITLE
fix(group): update member cover states

### DIFF
--- a/README.md
+++ b/README.md
@@ -470,6 +470,7 @@ elero_group:
 - Eine Gruppe benötigt 2–10 unterschiedliche Mitglieder; doppelte IDs werden bei der YAML-Validierung abgelehnt.
 - Nur vollständig kompatible RF- und Befehlsprofile verwenden ein natives Multi-Destination-RF-Paket. Inkompatible Gruppen nehmen semantische Command Intents atomar in alle Mitglieds-Queues oder in keine auf.
 - Ein nativer endgültiger Fehler fällt nur ohne bereits akzeptierte Wiederholung auf Mitglieder zurück; nach teilweiser nativer Übertragung wird nicht automatisch gefächert.
+- Angenommene Gruppenbefehle aktualisieren auch die Zustände und Positionsschätzungen der einzelnen Cover-Entities in Home Assistant.
 - Wenn ESPHome beim Kompilieren meldet, dass ein Mitglied nicht aufgelöst werden kann, prüfe `id:` und Schreibweise in `members`.
 - Vollständige Parameterliste: [Konfigurationsreferenz](docs/user/configuration.md#plattform-elero_group-gruppensteuerung)
 

--- a/components/elero/cover/EleroCover.cpp
+++ b/components/elero/cover/EleroCover.cpp
@@ -520,7 +520,11 @@ void EleroCover::start_movement(CoverOperation dir) {
       return;
   }
 
-  if(dir == this->current_operation)
+  this->apply_movement_state_(dir);
+}
+
+void EleroCover::apply_movement_state_(CoverOperation dir) {
+  if (dir == this->current_operation)
     return;
 
   this->current_operation = dir;
@@ -551,6 +555,64 @@ void EleroCover::finish_stop_verification_() {
     this->stop_urgent_active_ = false;
   }
   this->stop_verification_active_.store(false);
+}
+
+void EleroCover::prepare_group_intent(const CommandIntent &intent, float target_position) {
+  switch (intent.kind) {
+    case CommandIntentKind::OPEN:
+    case CommandIntentKind::CLOSE: {
+      const auto operation = intent.kind == CommandIntentKind::OPEN
+                                 ? COVER_OPERATION_OPENING
+                                 : COVER_OPERATION_CLOSING;
+      this->target_position_ = target_position >= COVER_CLOSED && target_position <= COVER_OPEN
+                                   ? target_position
+                                   : (operation == COVER_OPERATION_OPENING ? COVER_OPEN : COVER_CLOSED);
+      this->tilt = 0.0f;
+      this->last_operation_ = operation;
+      this->pending_movement_kind_ = intent.kind;
+      this->apply_movement_state_(operation);
+      break;
+    }
+    case CommandIntentKind::STOP:
+      if (this->current_operation != COVER_OPERATION_IDLE &&
+          this->open_duration_ > 0 && this->close_duration_ > 0)
+        this->recompute_position();
+      this->target_position_ = this->position;
+      this->stop_trigger_position_ = this->position;
+      this->stop_trigger_ms_ = millis();
+      this->stop_verification_active_.store(true);
+      this->pending_movement_start_ = false;
+      this->pending_stop_transition_ = true;
+      break;
+    case CommandIntentKind::TILT:
+      this->tilt = 1.0f;
+      this->publish_state();
+      break;
+    default:
+      break;
+  }
+}
+
+void EleroCover::handle_group_delivery_outcome(const DeliveryOutcome &outcome) {
+  if (delivery_packet_was_accepted(outcome.event)) {
+    this->handle_delivery_outcome_(outcome);
+    return;
+  }
+  const bool terminal_failure = outcome.event == DeliveryEvent::DROPPED ||
+      outcome.event == DeliveryEvent::STALE_CLEARED ||
+      (outcome.event == DeliveryEvent::FALLBACK_MEMBER_DROPPED && outcome.queue_size == 0);
+  if (!terminal_failure)
+    return;
+  if (outcome.intent.kind == CommandIntentKind::STOP && this->pending_stop_transition_) {
+    this->pending_stop_transition_ = false;
+    this->stop_trigger_ms_ = 0;
+    this->finish_stop_verification_();
+  }
+  if (this->pending_movement_start_ && outcome.intent.kind == this->pending_movement_kind_) {
+    this->pending_movement_start_ = false;
+    this->current_operation = COVER_OPERATION_IDLE;
+    this->publish_state(false);
+  }
 }
 
 void EleroCover::schedule_immediate_poll() {

--- a/components/elero/cover/EleroCover.h
+++ b/components/elero/cover/EleroCover.h
@@ -81,6 +81,8 @@ class EleroCover : public cover::Cover, public Component, public EleroBlindBase 
   }
 
   void schedule_immediate_poll() override;
+  void prepare_group_intent(const CommandIntent &intent, float target_position = -1.0f) override;
+  void handle_group_delivery_outcome(const DeliveryOutcome &outcome) override;
   void recompute_position();
   void start_movement(cover::CoverOperation op);
   bool is_at_target();
@@ -88,6 +90,7 @@ class EleroCover : public cover::Cover, public Component, public EleroBlindBase 
  protected:
   void control(const cover::CoverCall &call) override;
   void handle_delivery_outcome_(const DeliveryOutcome &outcome);
+  void apply_movement_state_(cover::CoverOperation operation);
   void begin_movement_tracking_(cover::CoverOperation operation, uint32_t now);
   void finish_stop_verification_();
 

--- a/components/elero/elero.h
+++ b/components/elero/elero.h
@@ -311,6 +311,10 @@ class EleroBlindBase {
   virtual CommandDeliveryConfig get_command_delivery_config() const = 0;
   virtual CommandIntentDelivery *get_command_delivery() = 0;
   virtual bool should_defer_intent(const CommandIntent &) const { return false; }
+  /// Mirror an accepted group intent into this member's optimistic entity state.
+  virtual void prepare_group_intent(const CommandIntent &intent, float target_position = -1.0f) = 0;
+  /// Forward native group delivery progress to the member state machine.
+  virtual void handle_group_delivery_outcome(const DeliveryOutcome &outcome) = 0;
   // RF params retained for configuration/status serialization
   virtual uint8_t get_hop() const = 0;
   virtual uint8_t get_pck_inf0() const = 0;

--- a/components/elero_group/EleroGroupCover.cpp
+++ b/components/elero_group/EleroGroupCover.cpp
@@ -91,8 +91,9 @@ void EleroGroupCover::control(const cover::CoverCall &call) {
                                                               : CommandIntentKind::CLOSE;
         intents.push_back({kind, 0});
       }
-      if (intent_was_accepted(this->submit_member_targets_(intents)))
-        this->current_operation = cover::COVER_OPERATION_OPENING;
+      if (intent_was_accepted(this->submit_member_targets_(intents, pos)))
+        this->current_operation = pos > this->position ? cover::COVER_OPERATION_OPENING
+                                                       : cover::COVER_OPERATION_CLOSING;
     }
     this->publish_state();
   }
@@ -114,6 +115,10 @@ IntentSubmitResult EleroGroupCover::submit_group_intent_(const CommandIntent &in
   if (!this->native_group_)
     return this->submit_to_members_(intent);
   const auto result = this->native_delivery_.submit(intent, millis());
+  if (intent_was_accepted(result)) {
+    std::vector<CommandIntent> intents(this->members_.size(), intent);
+    this->prepare_member_states_(intents);
+  }
   if (group_delivery_policy::reject_native_submit_without_fanout(result)) {
     // Keep all compatible group work in the native lane. Sending only this
     // newest command through members would overtake its older native backlog.
@@ -129,7 +134,8 @@ IntentSubmitResult EleroGroupCover::submit_to_members_(const CommandIntent &inte
   return this->submit_member_targets_(intents);
 }
 
-IntentSubmitResult EleroGroupCover::submit_member_targets_(const std::vector<CommandIntent> &intents) {
+IntentSubmitResult EleroGroupCover::submit_member_targets_(const std::vector<CommandIntent> &intents,
+                                                            float target_position) {
   if (intents.size() != this->members_.size() || intents.empty())
     return IntentSubmitResult::REJECTED;
   std::vector<CommandIntentDelivery::AtomicIntentTarget> targets;
@@ -138,6 +144,8 @@ IntentSubmitResult EleroGroupCover::submit_member_targets_(const std::vector<Com
     targets.push_back({this->members_[i]->get_command_delivery(), intents[i],
                        this->members_[i]->should_defer_intent(intents[i])});
   const auto result = CommandIntentDelivery::submit_atomic(targets.data(), targets.size(), millis());
+  if (intent_was_accepted(result))
+    this->prepare_member_states_(intents, target_position);
   if (result == IntentSubmitResult::REJECTED) {
     ESP_LOGW(TAG, "Atomic member command rejected; no member queue was changed");
     if (this->parent_ != nullptr)
@@ -146,7 +154,15 @@ IntentSubmitResult EleroGroupCover::submit_member_targets_(const std::vector<Com
   return result;
 }
 
+void EleroGroupCover::prepare_member_states_(const std::vector<CommandIntent> &intents,
+                                             float target_position) {
+  for (size_t i = 0; i < this->members_.size(); i++)
+    this->members_[i]->prepare_group_intent(intents[i], target_position);
+}
+
 void EleroGroupCover::handle_native_outcome_(const DeliveryOutcome &outcome) {
+  for (auto *member : this->members_)
+    member->handle_group_delivery_outcome(outcome);
   if (outcome.event == DeliveryEvent::DROPPED ||
       outcome.event == DeliveryEvent::FALLBACK_MEMBER_DROPPED) {
     this->parent_->increment_tx_drop_count();

--- a/components/elero_group/EleroGroupCover.h
+++ b/components/elero_group/EleroGroupCover.h
@@ -30,7 +30,10 @@ class EleroGroupCover : public cover::Cover, public Component {
 
   IntentSubmitResult submit_group_intent_(const CommandIntent &intent);
   IntentSubmitResult submit_to_members_(const CommandIntent &intent);
-  IntentSubmitResult submit_member_targets_(const std::vector<CommandIntent> &intents);
+  IntentSubmitResult submit_member_targets_(const std::vector<CommandIntent> &intents,
+                                            float target_position = -1.0f);
+  void prepare_member_states_(const std::vector<CommandIntent> &intents,
+                              float target_position = -1.0f);
   bool can_use_native_group_() const;
   CommandDeliveryConfig build_native_config_() const;
   void handle_native_outcome_(const DeliveryOutcome &outcome);

--- a/docs/developer/development.md
+++ b/docs/developer/development.md
@@ -694,7 +694,7 @@ Optional parameters:
 - `assumed_state` (default `true`) — when true, open/close buttons are always enabled in HA (no position feedback from group)
 - `hide_members` (default `false`) — marks every listed member internal, hiding its individual Home Assistant entity globally, including membership in other groups
 
-Requires 2–10 distinct members. Compatible RF profiles and command mappings use a dedicated native multi-destination lane on the shared profile coordinator. Incompatible groups atomically admit semantic intents to every member lane or to none. Native final failure falls back only before any repeat was accepted; partial native delivery never automatically fans out.
+Requires 2–10 distinct members. Compatible RF profiles and command mappings use a dedicated native multi-destination lane on the shared profile coordinator. Incompatible groups atomically admit semantic intents to every member lane or to none. Native final failure falls back only before any repeat was accepted; partial native delivery never automatically fans out. Accepted group intents are mirrored into every member's ESPHome cover state so Home Assistant receives the same optimistic operation and dead-reckoned position updates as it does for individual control.
 
 ### Web UI (`elero_web`)
 

--- a/docs/user/configuration.md
+++ b/docs/user/configuration.md
@@ -340,6 +340,7 @@ elero_group:
 - Es müssen mindestens 2 und maximal 10 unterschiedliche Mitglieder angegeben werden (RF-Paketgrößenlimit); doppelte IDs werden bei der YAML-Validierung abgelehnt.
 - Ein natives Multi-Destination-RF-Paket wird nur verwendet, wenn Remote-Adresse, Kanal, Paketprofil, Payload und semantische Befehlszuordnung aller Mitglieder kompatibel sind. Andernfalls wird derselbe semantische Command Intent atomar in alle Mitglieder-Queues aufgenommen; ist eine Queue voll, wird keine davon verändert.
 - Bei einem endgültigen nativen Sendefehler wird nur dann auf Mitglieder zurückgefallen, wenn noch kein natives RF-Paket akzeptiert wurde. Nach teilweiser nativer Übertragung erfolgt kein automatisches Fan-out, um Doppelbefehle zu vermeiden.
+- Angenommene Gruppenbefehle aktualisieren auch den Zustand der einzelnen Cover-Entities in Home Assistant (z. B. `opening`, `closing` oder `idle`); konfigurierte Laufzeiten führen deren Positionsschätzung weiter.
 - Alle Mitglieder müssen als `cover: platform: elero` konfiguriert sein.
 
 **Fehlersuche:** Wenn ESPHome beim Kompilieren meldet, dass ein Mitglied nicht aufgelöst werden kann, prüfe ob das betreffende Cover eine `id:` hat und ob die Schreibweise in `members` exakt übereinstimmt.


### PR DESCRIPTION
## Summary
- mirror accepted group commands into each member cover state
- preserve dead-reckoned positions and stop verification semantics
- supersede stale member commands safely and honor custom STOP/CHECK bytes
- document Home Assistant member-state updates

## Validation
- [x] `git diff --check`
- [x] `python3 scripts/check_markdown_links.py`
- [ ] CMake/CTest (CMake is not installed in the workspace)
- [ ] ESPHome compile fixture (ESPHome is not installed in the workspace)