### PR TITLE
docs(governance): align validation guidance with CI

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,7 +19,8 @@ Refs #
 Run the smallest relevant checks from `docs/agent/CHECKS.md` and mark what applies.
 
 - [ ] Markdown links: `python3 scripts/check_markdown_links.py`
-- [ ] Python lint/format: `ruff check components/` and `ruff format --check components/`
+- [ ] ESPHome Python lint/format: `ruff check components/` and `ruff format --check components/`
+- [ ] HACS lint/compile: Ruff checks plus `python -m compileall custom_components/`
 - [ ] Python tests: `pytest tests/python/ -v --tb=short`
 - [ ] C++ unit tests: CMake build + CTest
 - [ ] ESPHome compile fixture(s)

--- a/docs/agent/ASSESSMENT.md
+++ b/docs/agent/ASSESSMENT.md
@@ -1,6 +1,6 @@
 # Repository Governance Assessment
 
-Last reviewed: 2026-06-03
+Last reviewed: 2026-07-21
 
 ## Maturity summary
 
@@ -16,7 +16,7 @@ Last reviewed: 2026-06-03
 
 - Short canonical `AGENTS.md` entry point with modular docs under `docs/agent/`.
 - Clear split between user docs, developer docs, and agent docs.
-- Strong CI coverage: Ruff, Python schema tests, C++ unit tests, ESPHome compile matrix, and frontend build.
+- Strong CI coverage: ESPHome and HACS Ruff checks, Python schema tests, C++ unit tests, ESPHome compile matrix, and frontend build.
 - Dependency-free Markdown local-link checker exists and passes.
 - Domain invariants are documented for RF safety, CC1101 task ownership, group covers, runtime adopted blinds, and web API safety.
 
@@ -51,14 +51,14 @@ Last reviewed: 2026-06-03
 
 ## Remaining governance debt
 
-- No formal ADR records exist yet beyond `docs/developer/adr/README.md`; significant future architecture changes should add one.
+- One accepted formal ADR currently records command-intent delivery; significant future architecture changes should add or supersede ADRs as needed.
 - Supply-chain scanning is optional and not wired into CI.
 - `frontend-legacy` remains in the repository as documented reference/rollback source; decide in a future cleanup whether to retain or remove it.
 - Hardware validation remains external/manual; docs correctly avoid implying automated RF hardware coverage.
 
 ## Recommended next steps
 
-1. Add ADRs for major RF/runtime design decisions when they next change.
+1. Keep the accepted command-intent delivery ADR current and add or supersede ADRs when other major RF/runtime decisions change.
 2. Decide whether `components/elero_web/frontend-legacy/` should remain as rollback/reference material or be removed in a future cleanup.
 3. Consider optional `npm audit` or OSV scanning for periodic dependency reviews.
 4. Keep issue/PR templates lightweight; adjust after observing contributor friction.

--- a/docs/agent/CHECKS.md
+++ b/docs/agent/CHECKS.md
@@ -81,15 +81,21 @@ When changing code or configuration that depends on ESPHome, RadioLib, Svelte, V
 
 ## Full local CI simulation
 
-From the repository root, run the relevant independent jobs from CI:
+From the repository root, run the independent checks represented in CI:
 
 ```bash
+python3 scripts/check_markdown_links.py
 ruff check components/
 ruff format --check components/
+ruff check custom_components/
+ruff format --check custom_components/
+python -m compileall custom_components/
 pytest tests/python/ -v --tb=short
 cmake -S tests -B tests/build -DCMAKE_BUILD_TYPE=Debug
 cmake --build tests/build --parallel
-cd tests/build && ctest --output-on-failure -V
+(cd tests/build && ctest --output-on-failure -V)
+for cfg in tests/configs/*.yaml; do esphome compile "$cfg"; done
+(cd components/elero_web/frontend && npm ci && npm run build)
 ```
 
-Then run ESPHome compile fixtures and the web UI build when the touched files require them.
+For targeted work, run only the smallest relevant sections above. The full set mirrors the independent CI jobs; hardware-dependent RF behavior still requires explicit manual validation.

--- a/docs/developer/development.md
+++ b/docs/developer/development.md
@@ -823,7 +823,8 @@ CI runs automatically on pushes to `main`, `dev`, `feat/**`, `fix/**`, and `docs
 | Job | What it does | Trigger |
 |-----|-------------|---------|
 | **markdown** | `python3 scripts/check_markdown_links.py` | Every push/PR |
-| **lint** | `ruff check components/` + `ruff format --check components/` | Every implementation push/PR; skipped on direct `docs/**` pushes |
+| **esphome-lint** | `ruff check components/` + `ruff format --check components/` | Every implementation push/PR; skipped on direct `docs/**` pushes |
+| **hacs-lint** | Ruff lint/format plus `compileall` for `custom_components/` | Every implementation push/PR; skipped on direct `docs/**` pushes |
 | **esphome-compile** | `esphome compile` across 8 config variants (matrix, `fail-fast: false`) | Every implementation push/PR; skipped on direct `docs/**` pushes |
 | **frontend-build** | `npm ci` + `npm run build` from `components/elero_web/frontend/`, then verifies generated `elero_web_ui.h` | Every implementation push/PR; skipped on direct `docs/**` pushes |
 | **unit-tests** | CMake configure/build plus `ctest --output-on-failure -V` | Every implementation push/PR; skipped on direct `docs/**` pushes |
@@ -866,7 +867,7 @@ This ensures compile warnings (like deprecation notices) automatically become tr
 
 The `main` branch is protected via GitHub branch protection rules:
 
-- **Required status check:** `ci-ok` must pass (gates on all CI jobs: lint, compile, frontend-build, unit-tests, python-tests)
+- **Required status check:** `ci-ok` must pass (gates on markdown, ESPHome lint, HACS lint, compile, frontend build, C++ unit tests, and Python tests)
 - **Strict mode:** PRs must be up-to-date with `main` before merging
 - **Force pushes:** blocked
 - **Branch deletion:** blocked
@@ -886,11 +887,7 @@ bash .github/scripts/protect-main.sh
 
 ### Automated (CI)
 
-The CI pipeline runs lint + 8-config compile matrix on every push. See [CI Pipeline](#ci-pipeline) above.
-
-**Planned but not yet implemented:**
-- C++ unit tests with GoogleTest (see GitHub issue #133)
-- Python schema validation tests with pytest (see GitHub issue #134)
+On implementation pushes and pull requests, CI runs ESPHome and HACS linting, the 8-config compile matrix, the frontend build, C++ unit tests with GoogleTest, and Python schema tests with pytest. Direct pushes to `docs/**` intentionally run only Markdown validation. See [CI Pipeline](#ci-pipeline) above.
 
 ### Manual Hardware Testing
 
@@ -911,7 +908,7 @@ Validation on real hardware before release:
 These rules are enforced by the `/review` Claude skill and should be checked before merging.
 
 ### Gate 1: CI Green
-All CI jobs must pass: lint clean + all 8 compile configs succeed.
+The `ci-ok` aggregate job must pass. For implementation changes this requires Markdown validation, ESPHome and HACS linting, all 8 compile configs, the frontend build, C++ unit tests, and Python tests. Direct `docs/**` pushes require Markdown validation only.
 
 ### Gate 2: Thread Safety
 - `std::atomic` loads use `std::memory_order_acquire`, stores use `std::memory_order_release`


### PR DESCRIPTION
## Summary

- align the developer CI job inventory with the current workflow
- remove stale claims that C++ and Python tests are not implemented
- make the documented full local CI simulation cover every CI job
- update the governance assessment and PR validation checklist

## Scope

This intentionally does not resolve the conflicting Companion architecture documents or change branch, release, or platform governance. Those decisions will be handled separately.

## Validation

- `git diff --check`
- `python3 scripts/check_markdown_links.py`

## Related issues

Refs #179
